### PR TITLE
chore: update ptauFiles URLs

### DIFF
--- a/cli/zkeys.config.yml
+++ b/cli/zkeys.config.yml
@@ -38,113 +38,113 @@ circuits:
 
 ptauFiles:
   1:
-    url: "https://hermezptau.blob.core.windows.net/ptau/powersOfTau28_hez_final_01.ptau"
+    url: "https://storage.googleapis.com/zkevm/ptau/powersOfTau28_hez_final_01.ptau"
     name: "powersOfTau28_hez_final_01.ptau"
 
   2:
-    url: "https://hermezptau.blob.core.windows.net/ptau/powersOfTau28_hez_final_02.ptau"
+    url: "https://storage.googleapis.com/zkevm/ptau/powersOfTau28_hez_final_02.ptau"
     name: "powersOfTau28_hez_final_02.ptau"
 
   3:
-    url: "https://hermezptau.blob.core.windows.net/ptau/powersOfTau28_hez_final_03.ptau"
+    url: "https://storage.googleapis.com/zkevm/ptau/powersOfTau28_hez_final_03.ptau"
     name: "powersOfTau28_hez_final_03.ptau"
 
   4:
-    url: "https://hermezptau.blob.core.windows.net/ptau/powersOfTau28_hez_final_04.ptau"
+    url: "https://storage.googleapis.com/zkevm/ptau/powersOfTau28_hez_final_04.ptau"
     name: "powersOfTau28_hez_final_04.ptau"
 
   5:
-    url: "https://hermezptau.blob.core.windows.net/ptau/powersOfTau28_hez_final_05.ptau"
+    url: "https://storage.googleapis.com/zkevm/ptau/powersOfTau28_hez_final_05.ptau"
     name: "powersOfTau28_hez_final_05.ptau"
 
   6:
-    url: "https://hermezptau.blob.core.windows.net/ptau/powersOfTau28_hez_final_06.ptau"
+    url: "https://storage.googleapis.com/zkevm/ptau/powersOfTau28_hez_final_06.ptau"
     name: "powersOfTau28_hez_final_06.ptau"
 
   7:
-    url: "https://hermezptau.blob.core.windows.net/ptau/powersOfTau28_hez_final_07.ptau"
+    url: "https://storage.googleapis.com/zkevm/ptau/powersOfTau28_hez_final_07.ptau"
     name: "powersOfTau28_hez_final_7.ptau"
 
   8:
-    url: "https://hermezptau.blob.core.windows.net/ptau/powersOfTau28_hez_final_08.ptau"
+    url: "https://storage.googleapis.com/zkevm/ptau/powersOfTau28_hez_final_08.ptau"
     name: "powersOfTau28_hez_final_8.ptau"
 
   9:
-    url: "https://hermezptau.blob.core.windows.net/ptau/powersOfTau28_hez_final_09.ptau"
+    url: "https://storage.googleapis.com/zkevm/ptau/powersOfTau28_hez_final_09.ptau"
     name: "powersOfTau28_hez_final_9.ptau"
 
   10:
-    url: "https://hermezptau.blob.core.windows.net/ptau/powersOfTau28_hez_final_10.ptau"
+    url: "https://storage.googleapis.com/zkevm/ptau/powersOfTau28_hez_final_10.ptau"
     name: "powersOfTau28_hez_final_10.ptau"
 
   11:
-    url: "https://hermezptau.blob.core.windows.net/ptau/powersOfTau28_hez_final_11.ptau"
+    url: "https://storage.googleapis.com/zkevm/ptau/powersOfTau28_hez_final_11.ptau"
     name: "powersOfTau28_hez_final_11.ptau"
 
   12:
-    url: "https://hermezptau.blob.core.windows.net/ptau/powersOfTau28_hez_final_12.ptau"
+    url: "https://storage.googleapis.com/zkevm/ptau/powersOfTau28_hez_final_12.ptau"
     name: "powersOfTau28_hez_final_12.ptau"
 
   13:
-    url: "https://hermezptau.blob.core.windows.net/ptau/powersOfTau28_hez_final_13.ptau"
+    url: "https://storage.googleapis.com/zkevm/ptau/powersOfTau28_hez_final_13.ptau"
     name: "powersOfTau28_hez_final_13.ptau"
 
   14:
-    url: "https://hermezptau.blob.core.windows.net/ptau/powersOfTau28_hez_final_14.ptau"
+    url: "https://storage.googleapis.com/zkevm/ptau/powersOfTau28_hez_final_14.ptau"
     name: "powersOfTau28_hez_final_14.ptau"
 
   15:
-    url: "https://hermezptau.blob.core.windows.net/ptau/powersOfTau28_hez_final_15.ptau"
+    url: "https://storage.googleapis.com/zkevm/ptau/powersOfTau28_hez_final_15.ptau"
     name: "powersOfTau28_hez_final_15.ptau"
 
   16:
-    url: "https://hermezptau.blob.core.windows.net/ptau/powersOfTau28_hez_final_16.ptau"
+    url: "https://storage.googleapis.com/zkevm/ptau/powersOfTau28_hez_final_16.ptau"
     name: "powersOfTau28_hez_final_16.ptau"
 
   17:
-    url: "https://hermezptau.blob.core.windows.net/ptau/powersOfTau28_hez_final_17.ptau"
+    url: "https://storage.googleapis.com/zkevm/ptau/powersOfTau28_hez_final_17.ptau"
     name: "powersOfTau28_hez_final_17.ptau"
 
   18:
-    url: "https://hermezptau.blob.core.windows.net/ptau/powersOfTau28_hez_final_18.ptau"
+    url: "https://storage.googleapis.com/zkevm/ptau/powersOfTau28_hez_final_18.ptau"
     name: "powersOfTau28_hez_final_18.ptau"
 
   19:
-    url: "https://hermezptau.blob.core.windows.net/ptau/powersOfTau28_hez_final_19.ptau"
+    url: "https://storage.googleapis.com/zkevm/ptau/powersOfTau28_hez_final_19.ptau"
     name: "powersOfTau28_hez_final_19.ptau"
 
   20:
-    url: "https://hermezptau.blob.core.windows.net/ptau/powersOfTau28_hez_final_20.ptau"
+    url: "https://storage.googleapis.com/zkevm/ptau/powersOfTau28_hez_final_20.ptau"
     name: "powersOfTau28_hez_final_20.ptau"
 
   21:
-    url: "https://www.dropbox.com/sh/mn47gnepqu88mzl/AABiMm_4UMnvU0VIkCDVX9XZa/powersOfTau28_hez_final_21.ptau?dl=1"
+    url: "https://storage.googleapis.com/zkevm/ptau/powersOfTau28_hez_final_21.ptau"
     name: "powersOfTau28_hez_final_21.ptau"
 
   22:
-    url: "https://www.dropbox.com/sh/mn47gnepqu88mzl/AAAzGtg94saShf044uZdwnuGa/powersOfTau28_hez_final_22.ptau?dl=1"
+    url: "https://storage.googleapis.com/zkevm/ptau/powersOfTau28_hez_final_22.ptau"
     name: "powersOfTau28_hez_final_22.ptau"
 
   23:
-    url: "https://www.dropbox.com/sh/mn47gnepqu88mzl/AACXdEyzF6V5G5SLwlcV24pYa/powersOfTau28_hez_final_23.ptau?dl=1"
+    url: "https://storage.googleapis.com/zkevm/ptau/powersOfTau28_hez_final_23.ptau"
     name: "powersOfTau28_hez_final_23.ptau"
 
   24:
-    url: "https://www.dropbox.com/sh/mn47gnepqu88mzl/AAAi2DHbiB5LhGGFRJ_M2DwVa/powersOfTau28_hez_final_24.ptau?dl=1"
+    url: "https://storage.googleapis.com/zkevm/ptau/powersOfTau28_hez_final_24.ptau"
     name: "powersOfTau28_hez_final_24.ptau"
 
   25:
-    url: "https://www.dropbox.com/sh/mn47gnepqu88mzl/AABtJqpgsk93Xe-gtLauqycTa/powersOfTau28_hez_final_25.ptau?dl=1"
+    url: "https://storage.googleapis.com/zkevm/ptau/powersOfTau28_hez_final_25.ptau"
     name: "powersOfTau28_hez_final_25.ptau"
 
   26:
-    url: "https://www.dropbox.com/sh/mn47gnepqu88mzl/AABcvvD2qA2wGwJCU2AhbwX0a/powersOfTau28_hez_final_26.ptau?dl=1"
+    url: "https://storage.googleapis.com/zkevm/ptau/powersOfTau28_hez_final_26.ptau"
     name: "powersOfTau28_hez_final_26.ptau"
 
   27:
-    url: "https://www.dropbox.com/sh/mn47gnepqu88mzl/AACxvAidsajKkHS5eMgpnHyZa/powersOfTau28_hez_final_27.ptau?dl=1"
+    url: "https://storage.googleapis.com/zkevm/ptau/powersOfTau28_hez_final_27.ptau"
     name: "powersOfTau28_hez_final_27.ptau"
 
   28:
-    url: "https://www.dropbox.com/sh/mn47gnepqu88mzl/AADgFSy_UnsSoDwOPy64tpCWa/powersOfTau28_hez_final.ptau?dl=1"
+    url: "https://storage.googleapis.com/zkevm/ptau/powersOfTau28_hez_final.ptau"
     name: "powersOfTau28_hez_final_28.ptau"


### PR DESCRIPTION
This PR updates the download links for the ptau files in the zkeys.config.yml file. The previous links were outdated and have been replaced with the new ones published on the https://github.com/iden3/snarkjs#7-prepare-phase-2