### PR TITLE
docs: adding licence link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Minimal Anti-Collusion Infrastructure
 
 [![CI][cli-actions-badge]][cli-actions-link]
-![License](https://img.shields.io/badge/license-MIT-green)
+[![License](https://img.shields.io/badge/license-MIT-green)](https://github.com/privacy-scaling-explorations/maci/blob/dev/LICENSE)
 
 Minimal Anti-Collusion Infrastructure (MACI) is an on-chain voting protocol which protects privacy and minimizes the risk of collusion and bribery.
 


### PR DESCRIPTION
Really small PR, curently clicking on the button leads to this : https://camo.githubusercontent.com/b8593b8ea2157c85d33229b9ae386247de6fcedee3c630642a5c8eb3b09d87ae/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f6c6963656e73652d4d49542d677265656e

Edited it so it leads to the license file, just like the  CI button just above
Have a nice evening 