### PR TITLE
docs: add Project Ideas page

### DIFF
--- a/website/versioned_docs/version-v1.x/project-ideas.md
+++ b/website/versioned_docs/version-v1.x/project-ideas.md
@@ -1,0 +1,14 @@
+---
+title: MACI Project Ideas
+description: Community-sourced ideas of projects you could build with MACI
+sidebar_label: MACI Project ideas
+sidebar_position: 23
+---
+
+# Build on MACI
+
+Are you interested in building on MACI but not sure what a useful project or application might be?
+
+Good news - you're in the right place!
+
+The MACI core team maintains a wishlist of community-sourced ideas to build with/for/on MACI. Check out our ["Project ideas to build with MACI" GitHub Discussion](https://github.com/privacy-scaling-explorations/maci/discussions/1136) for the up-to-date list! We encourage you to find inspiration here and comment in the discussion to suggest ideas of your own.


### PR DESCRIPTION
# Description

Create docs page that links to our [GH discussion on project ideas](https://github.com/privacy-scaling-explorations/maci/discussions/1136)

## Related issue(s)

None, came out of a Discord discussion. Primary motivation here is to add more visability/discoverability to this list for those who don't check GitHub discussions

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
