### PR TITLE
feat: Adds pnpm script to generateMaciKeyPair

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "test": "lerna run test --ignore maci-integrationtests --ignore maci-cli",
     "types": "lerna run types",
     "docs": "lerna run docs",
-    "prepare": "is-ci || husky"
+    "prepare": "is-ci || husky",
+    "genMaciKeyPair": "node packages/cli/build/ts/index.js genMaciKeyPair"
   },
   "author": "PSE",
   "devDependencies": {


### PR DESCRIPTION
# Description

<!-- Please provide a detailed description of the pull request you are opening. -->
- Creates a `pnpm` script to generate MACI key pair directly after building cli.

## Additional Notes

<!-- If there are any additional notes, requirements or special instructions related to this PR, please specify them here. -->

## Related issue(s)

<!-- Please list here with closing keywords any issues that this pull request is related to (fix #$ISSUE_NUMBER). -->
- resolves #1861 

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [X] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [X] I run and verified that all tests pass acording to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
