### PR TITLE
fix: ensure is-tallied and totalSignups are correct

### DIFF
--- a/apps/subgraph/src/maci.ts
+++ b/apps/subgraph/src/maci.ts
@@ -37,7 +37,8 @@ export function handleDeployPoll(event: DeployPollEvent): void {
   poll.updatedAt = event.block.timestamp;
   poll.owner = event.transaction.from;
 
-  poll.totalSignups = maci.totalSignups;
+  // No users would have joined the poll yet
+  poll.totalSignups = GraphBN.zero();
   poll.numMessages = GraphBN.zero();
   poll.maci = maci.id;
   poll.save();

--- a/packages/contracts/contracts/Poll.sol
+++ b/packages/contracts/contracts/Poll.sol
@@ -55,10 +55,6 @@ contract Poll is Clone, Params, Utilities, SnarkCommon, IPoll {
   /// @notice The number of messages that have been published
   uint256 public numMessages;
 
-  /// @notice The number of signups that have been processed
-  /// before the Poll ended (stateAq merged)
-  uint256 public totalSignups;
-
   /// @notice The actual depth of the state tree
   /// to be used as public input for the circuit
   uint8 public actualStateTreeDepth;
@@ -498,7 +494,6 @@ contract Poll is Clone, Params, Utilities, SnarkCommon, IPoll {
 
     // get number of joined users and cache in a var for later use
     uint256 _totalSignups = pollStateTree.numberOfLeaves;
-    totalSignups = _totalSignups;
 
     // dynamically determine the actual depth of the state tree
     uint8 depth = 1;
@@ -508,7 +503,7 @@ contract Poll is Clone, Params, Utilities, SnarkCommon, IPoll {
 
     actualStateTreeDepth = depth;
 
-    emit MergeState(mergedStateRoot, totalSignups);
+    emit MergeState(mergedStateRoot, _totalSignups);
   }
 
   /// @inheritdoc IPoll
@@ -519,13 +514,18 @@ contract Poll is Clone, Params, Utilities, SnarkCommon, IPoll {
 
   /// @inheritdoc IPoll
   function totalSignupsAndMessages() public view returns (uint256 numSUps, uint256 numMsgs) {
-    numSUps = totalSignups;
+    numSUps = pollStateTree.numberOfLeaves;
     numMsgs = numMessages;
   }
 
   /// @inheritdoc IPoll
+  function totalSignups() public view returns (uint256 signups) {
+    signups = pollStateTree.numberOfLeaves;
+  }
+
+  /// @inheritdoc IPoll
   function getMaciContract() public view returns (IMACI maci) {
-    return extContracts.maci;
+    maci = extContracts.maci;
   }
 
   /// @inheritdoc IPoll

--- a/packages/contracts/contracts/Tally.sol
+++ b/packages/contracts/contracts/Tally.sol
@@ -101,10 +101,16 @@ contract Tally is Clone, SnarkCommon, Hasher, DomainObjs, ITally {
   /// @return tallied whether all ballots are tallied
   function isTallied() public view returns (bool tallied) {
     (uint8 tallyProcessingStateTreeDepth, , ) = poll.treeDepths();
-    (uint256 totalSignups, ) = poll.totalSignupsAndMessages();
+    uint256 totalSignups = poll.totalSignups();
 
-    // Require that there are untallied ballots left
-    tallied = tallyBatchNum * (TREE_ARITY ** tallyProcessingStateTreeDepth) >= totalSignups;
+    uint256 pollEndDate = poll.endDate();
+
+    if (pollEndDate > block.timestamp) {
+      tallied = false;
+    } else {
+      // Require that there are untallied ballots left
+      tallied = tallyBatchNum * (TREE_ARITY ** tallyProcessingStateTreeDepth) >= totalSignups;
+    }
   }
 
   /// @notice Update the state and ballot root commitment

--- a/packages/contracts/contracts/interfaces/IPoll.sol
+++ b/packages/contracts/contracts/interfaces/IPoll.sol
@@ -125,4 +125,8 @@ interface IPoll {
   /// @param element The hash of thestate leaf
   /// @return index The index of the state leaf in the state tree
   function getStateIndex(uint256 element) external view returns (uint40);
+
+  /// @notice Get the number of signups (users that joined the poll)
+  /// @return signups The number of signups
+  function totalSignups() external view returns (uint256 signups);
 }

--- a/packages/contracts/tasks/helpers/ProofGenerator.ts
+++ b/packages/contracts/tasks/helpers/ProofGenerator.ts
@@ -114,7 +114,7 @@ export class ProofGenerator {
         .queryFilter(maciContract.filters.DeployPoll(), startBlock)
         .then((events) => events[0]?.blockNumber ?? 0),
       maciContract.getStateTreeRoot(),
-      maciContract.totalSignups(),
+      pollContract.totalSignups(),
     ]);
     const defaultStartBlock = Math.min(defaultStartBlockPoll, defaultStartBlockSignup);
     let fromBlock = startBlock ? Number(startBlock) : defaultStartBlock;

--- a/packages/contracts/tests/Tally.test.ts
+++ b/packages/contracts/tests/Tally.test.ts
@@ -163,6 +163,10 @@ describe("VoteTally", function test() {
     );
   });
 
+  it("isTallied() should return false before the poll has ended", async () => {
+    expect(await tallyContract.isTallied()).to.eq(false);
+  });
+
   it("tallyVotes() should fail as the messages have not been processed yet", async () => {
     await timeTravel(signer.provider! as unknown as EthereumProvider, duration + 1);
 

--- a/packages/sdk/ts/poll/poll.ts
+++ b/packages/sdk/ts/poll/poll.ts
@@ -15,7 +15,6 @@ export const getPoll = async ({ maciAddress, signer, provider, pollId }: IGetPol
   const {
     id,
     poll: pollContract,
-    maci: maciContract,
     tally: tallyContract,
   } = await getPollContracts({ maciAddress, pollId, signer, provider });
 
@@ -25,7 +24,7 @@ export const getPoll = async ({ maciAddress, signer, provider, pollId }: IGetPol
     pollContract.getAddress(),
   ]);
   const isMerged = mergedStateRoot !== BigInt(0);
-  const totalSignups = await (isMerged ? pollContract.totalSignups() : maciContract.totalSignups());
+  const totalSignups = await pollContract.totalSignups();
 
   // get the poll mode
   const mode = await tallyContract.mode();


### PR DESCRIPTION
# Description

Ensure that is tallied does not return true if called before the poll ends. Also allow to query the number of total signups without waiting for the poll to end.


