### PR TITLE
fix: update zk-SNARK circuits documentation link to the latest working URL

### DIFF
--- a/packages/circuits/README.md
+++ b/packages/circuits/README.md
@@ -12,7 +12,7 @@ The main circuits are:
 
 The rest of the circuits are utilities templates that are required for the main circuits to work correctly. These include utilities such as float math, conversion of private keys, and Poseidon hashing/encryption.
 
-Please refer to the [documentation](https://maci.pse.dev/docs/category/zk-snark-circuits) for a more in depth explanation.
+Please refer to the [documentation](https://maci.pse.dev/docs/technical-references/zk-snark-circuits/) for a more in depth explanation.
 
 [circuits-npm-badge]: https://img.shields.io/npm/v/maci-circuits.svg
 [circuits-npm-link]: https://www.npmjs.com/package/maci-circuits


### PR DESCRIPTION
# Description

The previous documentation link was broken (404). Updated to the current, working documentation for zk-SNARK circuits at https://maci.pse.dev/docs/technical-references/zk-snark-circuits/.



- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [ ] I ran and verified that all tests pass according to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
