### PR TITLE
fix(contracts): small typo

### DIFF
--- a/packages/contracts/contracts/crypto/BabyJubJub.sol
+++ b/packages/contracts/contracts/crypto/BabyJubJub.sol
@@ -28,7 +28,7 @@ library CurveBabyJubJub {
       return (_x2, _y2);
     }
 
-    if (_x2 == 0 && _y1 == 0) {
+    if (_x2 == 0 && _y2 == 0) {
       return (_x1, _y1);
     }
 


### PR DESCRIPTION
pointAdd function incorrectly used y1 instead of _y2 for the second point. 
I know you don't accept typo PRs, but this one looks reasonable and important