### PR TITLE
feat: make ESupportedChains exportable so apps can use it

### DIFF
--- a/apps/coordinator/package.json
+++ b/apps/coordinator/package.json
@@ -96,6 +96,10 @@
       "<rootDir>/tests"
     ],
     "testRegex": ".*\\.test\\.ts$",
+    "moduleNameMapper": {
+      "^@excubiae/contracts$": "<rootDir>/ts/jest/__mocks__/@excubiae/contracts.ts",
+      "^@openzeppelin/merkle-tree$": "<rootDir>/ts/jest/__mocks__/@openzeppelin/merkle-tree.ts"
+    },
     "transform": {
       "^.+\\.js$": [
         "<rootDir>/ts/jest/transform.js",

--- a/apps/coordinator/tests/e2e.deploy.test.ts
+++ b/apps/coordinator/tests/e2e.deploy.test.ts
@@ -1,5 +1,5 @@
 import { Keypair } from "@maci-protocol/domainobjs";
-import { ContractStorage, isArm, joinPoll, signup, sleepUntil } from "@maci-protocol/sdk";
+import { ContractStorage, isArm, joinPoll, signup, sleepUntil, ESupportedChains } from "@maci-protocol/sdk";
 import { ValidationPipe, type INestApplication } from "@nestjs/common";
 import { Test } from "@nestjs/testing";
 import dotenv from "dotenv";
@@ -10,7 +10,7 @@ import { Hex, PublicClient, zeroAddress } from "viem";
 import path from "path";
 
 import { AppModule } from "../ts/app.module";
-import { ESupportedNetworks, getSigner } from "../ts/common";
+import { getSigner } from "../ts/common";
 import { getPublicClient } from "../ts/common/accountAbstraction";
 import {
   pollDuration,
@@ -45,7 +45,7 @@ jest.setTimeout(700000); // Sets timeout to 700 seconds
 
 const PORT = process.env.COORDINATOR_PORT || 3000;
 const TEST_URL = `http://localhost:${PORT}/v1`;
-const CHAIN = ESupportedNetworks.OPTIMISM_SEPOLIA;
+const CHAIN = ESupportedChains.OptimismSepolia;
 
 const REGEX_SUBGRAPH = /^https:\/\/api\.studio\.thegraph\.com\/query\/\d+\/maci-subgraph\/v0\.0\.\d+$/;
 
@@ -120,7 +120,7 @@ describe("E2E Deployment Tests", () => {
   test("should use OP Sepolia RPC in E2E", async () => {
     const network = await signer.provider?.getNetwork();
 
-    expect(network?.name).toBe(ESupportedNetworks.OPTIMISM_SEPOLIA);
+    expect(network?.name).toBe(ESupportedChains.OptimismSepolia);
   });
 
   test("should return true in the health check", async () => {

--- a/apps/coordinator/tests/e2e.redis.test.ts
+++ b/apps/coordinator/tests/e2e.redis.test.ts
@@ -1,7 +1,6 @@
-import { EMode } from "@maci-protocol/sdk";
+import { EMode, ESupportedChains } from "@maci-protocol/sdk";
 import { createClient, RedisClientType } from "@redis/client";
 
-import { ESupportedNetworks } from "../ts/common";
 import { RedisService } from "../ts/redis/redis.service";
 import { IScheduledPoll } from "../ts/redis/types";
 import { getPollKeyFromObject } from "../ts/redis/utils";
@@ -12,7 +11,7 @@ const scheduledPoll: IScheduledPoll = {
   maciAddress: "0xb83074Ac11fc569AC12F1b7D0C0a6809c3dc355b",
   pollId: "5",
   mode: EMode.NON_QV,
-  chain: ESupportedNetworks.OPTIMISM_SEPOLIA,
+  chain: ESupportedChains.OptimismSepolia,
   endDate: 1752534000,
   deploymentBlockNumber: 1,
   merged: false,

--- a/apps/coordinator/tests/utils.ts
+++ b/apps/coordinator/tests/utils.ts
@@ -1,3 +1,4 @@
+import { ESupportedChains } from "@maci-protocol/sdk";
 import dotenv from "dotenv";
 import { getBytes, hashMessage, type Signer } from "ethers";
 import { createWalletClient, formatEther, Hex, http, parseEther } from "viem";
@@ -6,7 +7,6 @@ import { optimismSepolia } from "viem/chains";
 
 import fs from "fs";
 
-import { ESupportedNetworks } from "../ts/common";
 import { getPublicClient } from "../ts/common/accountAbstraction";
 import { CryptoService } from "../ts/crypto/crypto.service";
 
@@ -44,7 +44,7 @@ export const rechargeGasIfNeeded = async (
   minimumValueOfEther: string,
   valueToSendOfEther: string,
 ): Promise<void> => {
-  const publicClient = await getPublicClient(ESupportedNetworks.OPTIMISM_SEPOLIA);
+  const publicClient = await getPublicClient(ESupportedChains.OptimismSepolia);
   const balance = await publicClient.getBalance({ address });
   const balanceAsEther = formatEther(balance);
 

--- a/apps/coordinator/ts/common/__tests__/common.test.ts
+++ b/apps/coordinator/ts/common/__tests__/common.test.ts
@@ -1,36 +1,43 @@
+import { ESupportedChains } from "@maci-protocol/sdk";
 import {
   mainnet,
   sepolia,
   arbitrum,
+  localhost,
   arbitrumSepolia,
   baseSepolia,
   lineaSepolia,
   scrollSepolia,
   scroll,
   base,
-  holesky,
   linea,
-  bsc,
   gnosis,
   polygon,
   optimism,
   optimismSepolia,
+  hardhat,
+  polygonAmoy,
+  polygonZkEvm,
+  polygonZkEvmCardona,
+  zksyncSepoliaTestnet,
+  zksync,
+  gnosisChiado,
 } from "viem/chains";
 
 import { getBundlerClient, getPublicClient, getZeroDevBundlerRPCUrl } from "../accountAbstraction";
 import { getRpcUrl } from "../chain";
 import { ErrorCodes } from "../errors";
-import { ESupportedNetworks, viemChain } from "../networks";
+import { viemChain } from "../networks";
 
 describe("common", () => {
   describe("getPublicClient", () => {
     test("should return a public client", async () => {
-      const publicClient = await getPublicClient(ESupportedNetworks.OPTIMISM_SEPOLIA);
+      const publicClient = await getPublicClient(ESupportedChains.OptimismSepolia);
       expect(publicClient).toBeDefined();
     });
 
     test("should throw when given an unsupported network", async () => {
-      await expect(() => getPublicClient("Unsupported" as ESupportedNetworks)).rejects.toThrow(
+      await expect(() => getPublicClient("Unsupported" as ESupportedChains)).rejects.toThrow(
         ErrorCodes.UNSUPPORTED_NETWORK.toString(),
       );
     });
@@ -38,23 +45,27 @@ describe("common", () => {
 
   describe("getZeroDevBundlerRPCUrl", () => {
     test("should throw when the network is not supported", () => {
-      expect(() => getZeroDevBundlerRPCUrl("Unsupported" as ESupportedNetworks)).toThrow(
+      expect(() => getZeroDevBundlerRPCUrl("Unsupported" as ESupportedChains)).toThrow(
         ErrorCodes.UNSUPPORTED_NETWORK.toString(),
       );
     });
 
     test("should return an RPCUrl for a supported network", () => {
-      const rpcUrlOPS = getZeroDevBundlerRPCUrl(ESupportedNetworks.OPTIMISM_SEPOLIA);
+      const rpcUrlOPS = getZeroDevBundlerRPCUrl(ESupportedChains.OptimismSepolia);
       expect(rpcUrlOPS).toBeDefined();
 
-      const rpcUrlOP = getZeroDevBundlerRPCUrl(ESupportedNetworks.OPTIMISM);
+      const rpcUrlOP = getZeroDevBundlerRPCUrl(ESupportedChains.Optimism);
       expect(rpcUrlOP).toBeDefined();
+    });
+
+    test("should throw when a unsupported zero dev network is given", () => {
+      expect(() => getZeroDevBundlerRPCUrl(ESupportedChains.Base)).toThrow(ErrorCodes.UNSUPPORTED_NETWORK.toString());
     });
   });
 
   describe("getBundlerClient", () => {
     test("should throw when the network is not supported", () => {
-      expect(() => getBundlerClient("Unsupported" as ESupportedNetworks)).toThrow(
+      expect(() => getBundlerClient("Unsupported" as ESupportedChains)).toThrow(
         ErrorCodes.UNSUPPORTED_NETWORK.toString(),
       );
     });
@@ -62,14 +73,14 @@ describe("common", () => {
 
   describe("getRpcUrl", () => {
     test("should throw when given an unsupported network", async () => {
-      await expect(() => getRpcUrl("Unsupported" as ESupportedNetworks)).rejects.toThrow(
+      await expect(() => getRpcUrl("Unsupported" as ESupportedChains)).rejects.toThrow(
         ErrorCodes.UNSUPPORTED_NETWORK.toString(),
       );
     });
 
     test("should throw when COORDINATOR_RPC_URL is not set", async () => {
       delete process.env.COORDINATOR_RPC_URL;
-      await expect(() => getRpcUrl(ESupportedNetworks.OPTIMISM_SEPOLIA)).rejects.toThrow(
+      await expect(() => getRpcUrl(ESupportedChains.OptimismSepolia)).rejects.toThrow(
         ErrorCodes.COORDINATOR_RPC_URL_NOT_SET.toString(),
       );
     });
@@ -77,26 +88,32 @@ describe("common", () => {
 
   describe("viemChain", () => {
     test("should return correct chain for all supported networks", () => {
-      expect(viemChain(ESupportedNetworks.ETHEREUM)).toBe(mainnet);
-      expect(viemChain(ESupportedNetworks.ETHEREUM_SEPOLIA)).toBe(sepolia);
-      expect(viemChain(ESupportedNetworks.ARBITRUM_ONE)).toBe(arbitrum);
-      expect(viemChain(ESupportedNetworks.ARBITRUM_SEPOLIA)).toBe(arbitrumSepolia);
-      expect(viemChain(ESupportedNetworks.BASE_SEPOLIA)).toBe(baseSepolia);
-      expect(viemChain(ESupportedNetworks.LINEA_SEPOLIA)).toBe(lineaSepolia);
-      expect(viemChain(ESupportedNetworks.SCROLL_SEPOLIA)).toBe(scrollSepolia);
-      expect(viemChain(ESupportedNetworks.SCROLL)).toBe(scroll);
-      expect(viemChain(ESupportedNetworks.BASE)).toBe(base);
-      expect(viemChain(ESupportedNetworks.HOLESKY)).toBe(holesky);
-      expect(viemChain(ESupportedNetworks.LINEA)).toBe(linea);
-      expect(viemChain(ESupportedNetworks.BSC)).toBe(bsc);
-      expect(viemChain(ESupportedNetworks.GNOSIS_CHAIN)).toBe(gnosis);
-      expect(viemChain(ESupportedNetworks.POLYGON)).toBe(polygon);
-      expect(viemChain(ESupportedNetworks.OPTIMISM)).toBe(optimism);
-      expect(viemChain(ESupportedNetworks.OPTIMISM_SEPOLIA)).toBe(optimismSepolia);
+      expect(viemChain(ESupportedChains.Mainnet)).toBe(mainnet);
+      expect(viemChain(ESupportedChains.Sepolia)).toBe(sepolia);
+      expect(viemChain(ESupportedChains.Optimism)).toBe(optimism);
+      expect(viemChain(ESupportedChains.OptimismSepolia)).toBe(optimismSepolia);
+      expect(viemChain(ESupportedChains.Scroll)).toBe(scroll);
+      expect(viemChain(ESupportedChains.ScrollSepolia)).toBe(scrollSepolia);
+      expect(viemChain(ESupportedChains.Arbitrum)).toBe(arbitrum);
+      expect(viemChain(ESupportedChains.ArbitrumSepolia)).toBe(arbitrumSepolia);
+      expect(viemChain(ESupportedChains.Base)).toBe(base);
+      expect(viemChain(ESupportedChains.BaseSepolia)).toBe(baseSepolia);
+      expect(viemChain(ESupportedChains.Gnosis)).toBe(gnosis);
+      expect(viemChain(ESupportedChains.GnosisChiado)).toBe(gnosisChiado);
+      expect(viemChain(ESupportedChains.Polygon)).toBe(polygon);
+      expect(viemChain(ESupportedChains.PolygonAmoy)).toBe(polygonAmoy);
+      expect(viemChain(ESupportedChains.Linea)).toBe(linea);
+      expect(viemChain(ESupportedChains.LineaSepolia)).toBe(lineaSepolia);
+      expect(viemChain(ESupportedChains.ZkSyncEra)).toBe(zksync);
+      expect(viemChain(ESupportedChains.ZkSyncSepolia)).toBe(zksyncSepoliaTestnet);
+      expect(viemChain(ESupportedChains.PolygonZkEvm)).toBe(polygonZkEvm);
+      expect(viemChain(ESupportedChains.PolygonCardonaZkEvm)).toBe(polygonZkEvmCardona);
+      expect(viemChain(ESupportedChains.Hardhat)).toBe(hardhat);
+      expect(viemChain(ESupportedChains.Localhost)).toBe(localhost);
     });
 
     test("should throw error for unsupported network", () => {
-      expect(() => viemChain("UNSUPPORTED_NETWORK" as ESupportedNetworks)).toThrow(
+      expect(() => viemChain("UNSUPPORTED_NETWORK" as ESupportedChains)).toThrow(
         ErrorCodes.UNSUPPORTED_NETWORK.toString(),
       );
     });

--- a/apps/coordinator/ts/common/accountAbstraction.ts
+++ b/apps/coordinator/ts/common/accountAbstraction.ts
@@ -1,3 +1,4 @@
+import { ESupportedChains } from "@maci-protocol/sdk";
 import { deserializePermissionAccount } from "@zerodev/permissions";
 import { toECDSASigner } from "@zerodev/permissions/signers";
 import { createKernelAccountClient } from "@zerodev/sdk";
@@ -11,7 +12,7 @@ import type { BundlerClientType, KernelClientType, PublicClientHTTPType } from "
 
 import { getRpcUrl } from "./chain";
 import { ErrorCodes } from "./errors";
-import { ESupportedNetworks, viemChain } from "./networks";
+import { viemChain } from "./networks";
 
 dotenv.config();
 
@@ -21,7 +22,7 @@ dotenv.config();
  * @param chainName - the name of the chain to use
  * @returns the public client
  */
-export const getPublicClient = async (chainName: ESupportedNetworks): Promise<PublicClientHTTPType> =>
+export const getPublicClient = async (chainName: ESupportedChains): Promise<PublicClientHTTPType> =>
   createPublicClient({
     transport: http(await getRpcUrl(chainName)),
     chain: viemChain(chainName),
@@ -33,11 +34,11 @@ export const getPublicClient = async (chainName: ESupportedNetworks): Promise<Pu
  * @param network - the network we are on
  * @returns the ZeroDev bundler RPC URL
  */
-export const getZeroDevBundlerRPCUrl = (network: ESupportedNetworks): string => {
+export const getZeroDevBundlerRPCUrl = (network: ESupportedChains): string => {
   switch (network) {
-    case ESupportedNetworks.OPTIMISM_SEPOLIA:
+    case ESupportedChains.OptimismSepolia:
       return process.env.ZERODEV_BUNDLER_RPC_OP_SEPOLIA || "";
-    case ESupportedNetworks.OPTIMISM:
+    case ESupportedChains.Optimism:
       return process.env.ZERODEV_BUNDLER_RPC_OP || "";
     default:
       throw new Error(ErrorCodes.UNSUPPORTED_NETWORK.toString());
@@ -50,7 +51,7 @@ export const getZeroDevBundlerRPCUrl = (network: ESupportedNetworks): string => 
  * @param chainName - the chain name
  * @returns the bundler client
  */
-export const getBundlerClient = (chainName: ESupportedNetworks): BundlerClientType =>
+export const getBundlerClient = (chainName: ESupportedChains): BundlerClientType =>
   createBundlerClient({
     transport: http(getZeroDevBundlerRPCUrl(chainName)),
     chain: viemChain(chainName),
@@ -72,7 +73,7 @@ export const addressOffset = 26;
 export const getKernelClient = async (
   sessionKey: Hex,
   approval: string,
-  chain: ESupportedNetworks,
+  chain: ESupportedChains,
 ): Promise<KernelClientType> => {
   const bundlerUrl = getZeroDevBundlerRPCUrl(chain);
   const publicClient = await getPublicClient(chain);

--- a/apps/coordinator/ts/common/chain.ts
+++ b/apps/coordinator/ts/common/chain.ts
@@ -1,7 +1,7 @@
+import { ESupportedChains } from "@maci-protocol/sdk";
 import { JsonRpcProvider, Signer, Wallet } from "ethers";
 
 import { ErrorCodes } from "./errors";
-import { ESupportedNetworks } from "./networks";
 
 /**
  * Get the RPC url for the chain we need to interact with
@@ -9,14 +9,14 @@ import { ESupportedNetworks } from "./networks";
  * @param network - the network we want to interact with
  * @returns the RPC url for the network
  */
-export const getRpcUrl = async (network: ESupportedNetworks): Promise<string> => {
+export const getRpcUrl = async (network: ESupportedChains): Promise<string> => {
   const rpcUrl = process.env.COORDINATOR_RPC_URL;
 
   if (!rpcUrl) {
     return Promise.reject(new Error(ErrorCodes.COORDINATOR_RPC_URL_NOT_SET.toString()));
   }
 
-  if (!Object.values(ESupportedNetworks).includes(network)) {
+  if (!Object.values(ESupportedChains).includes(network)) {
     return Promise.reject(new Error(ErrorCodes.UNSUPPORTED_NETWORK.toString()));
   }
 
@@ -28,7 +28,7 @@ export const getRpcUrl = async (network: ESupportedNetworks): Promise<string> =>
  * @param chain
  * @returns
  */
-export const getSigner = async (chain: ESupportedNetworks): Promise<Signer> => {
+export const getSigner = async (chain: ESupportedChains): Promise<Signer> => {
   const wallet = process.env.PRIVATE_KEY
     ? new Wallet(process.env.PRIVATE_KEY)
     : Wallet.fromPhrase(process.env.MNEMONIC!);

--- a/apps/coordinator/ts/common/index.ts
+++ b/apps/coordinator/ts/common/index.ts
@@ -1,5 +1,4 @@
 export { ErrorCodes } from "./errors";
-export { ESupportedNetworks } from "./networks";
 export * from "./chain";
 export * from "./accountAbstraction";
 export * from "./types";

--- a/apps/coordinator/ts/common/networks.ts
+++ b/apps/coordinator/ts/common/networks.ts
@@ -1,12 +1,13 @@
+import { ESupportedChains } from "@maci-protocol/sdk";
 import {
   arbitrum,
   arbitrumSepolia,
   base,
   baseSepolia,
-  bsc,
   type Chain,
   gnosis,
-  holesky,
+  gnosisChiado,
+  hardhat,
   linea,
   lineaSepolia,
   localhost,
@@ -14,33 +15,17 @@ import {
   optimism,
   optimismSepolia,
   polygon,
+  polygonAmoy,
+  polygonZkEvm,
+  polygonZkEvmCardona,
   scroll,
   scrollSepolia,
   sepolia,
+  zksync,
+  zksyncSepoliaTestnet,
 } from "viem/chains";
 
 import { ErrorCodes } from "./errors";
-
-export enum ESupportedNetworks {
-  ETHEREUM = "mainnet",
-  OPTIMISM = "optimism",
-  OPTIMISM_SEPOLIA = "optimism-sepolia",
-  BSC = "bsc",
-  BSC_CHAPEL = "chapel",
-  GNOSIS_CHAIN = "gnosis",
-  POLYGON = "matic",
-  ARBITRUM_ONE = "arbitrum-one",
-  HOLESKY = "holesky",
-  LINEA_SEPOLIA = "linea-sepolia",
-  BASE_SEPOLIA = "base-sepolia",
-  ETHEREUM_SEPOLIA = "sepolia",
-  ARBITRUM_SEPOLIA = "arbitrum-sepolia",
-  LINEA = "linea",
-  BASE = "base",
-  SCROLL_SEPOLIA = "scroll-sepolia",
-  SCROLL = "scroll",
-  LOCALHOST = "localhost",
-}
 
 /**
  * Get the Viem chain for a given network
@@ -48,41 +33,52 @@ export enum ESupportedNetworks {
  * @param network - the network to get the chain for
  * @returns the Viem chain
  */
-export const viemChain = (network: ESupportedNetworks): Chain => {
+export const viemChain = (network: ESupportedChains): Chain => {
   switch (network) {
-    case ESupportedNetworks.ETHEREUM:
+    case ESupportedChains.Mainnet:
       return mainnet;
-    case ESupportedNetworks.ETHEREUM_SEPOLIA:
+    case ESupportedChains.Sepolia:
       return sepolia;
-    case ESupportedNetworks.ARBITRUM_ONE:
-      return arbitrum;
-    case ESupportedNetworks.ARBITRUM_SEPOLIA:
-      return arbitrumSepolia;
-    case ESupportedNetworks.BASE_SEPOLIA:
-      return baseSepolia;
-    case ESupportedNetworks.LINEA_SEPOLIA:
-      return lineaSepolia;
-    case ESupportedNetworks.SCROLL_SEPOLIA:
-      return scrollSepolia;
-    case ESupportedNetworks.SCROLL:
-      return scroll;
-    case ESupportedNetworks.BASE:
-      return base;
-    case ESupportedNetworks.HOLESKY:
-      return holesky;
-    case ESupportedNetworks.LINEA:
-      return linea;
-    case ESupportedNetworks.BSC:
-      return bsc;
-    case ESupportedNetworks.GNOSIS_CHAIN:
-      return gnosis;
-    case ESupportedNetworks.POLYGON:
-      return polygon;
-    case ESupportedNetworks.OPTIMISM:
+    case ESupportedChains.Optimism:
       return optimism;
-    case ESupportedNetworks.OPTIMISM_SEPOLIA:
+    case ESupportedChains.OptimismSepolia:
       return optimismSepolia;
-    case ESupportedNetworks.LOCALHOST:
+    case ESupportedChains.Scroll:
+      return scroll;
+    case ESupportedChains.ScrollSepolia:
+      return scrollSepolia;
+    case ESupportedChains.Arbitrum:
+      return arbitrum;
+    case ESupportedChains.ArbitrumSepolia:
+      return arbitrumSepolia;
+    case ESupportedChains.Base:
+      return base;
+    case ESupportedChains.BaseSepolia:
+      return baseSepolia;
+    case ESupportedChains.Gnosis:
+      return gnosis;
+    case ESupportedChains.GnosisChiado:
+      return gnosisChiado;
+    case ESupportedChains.Polygon:
+      return polygon;
+    case ESupportedChains.PolygonAmoy:
+      return polygonAmoy;
+    case ESupportedChains.Linea:
+      return linea;
+    case ESupportedChains.LineaSepolia:
+      return lineaSepolia;
+    case ESupportedChains.ZkSyncEra:
+      return zksync;
+    case ESupportedChains.ZkSyncSepolia:
+      return zksyncSepoliaTestnet;
+    case ESupportedChains.PolygonZkEvm:
+      return polygonZkEvm;
+    case ESupportedChains.PolygonCardonaZkEvm:
+      return polygonZkEvmCardona;
+    // coverage is not supported by viem and it wont be used in the coordinator
+    case ESupportedChains.Hardhat:
+      return hardhat;
+    case ESupportedChains.Localhost:
       return localhost;
     default:
       throw new Error(ErrorCodes.UNSUPPORTED_NETWORK.toString());

--- a/apps/coordinator/ts/deployer/__tests__/deployer.controller.test.ts
+++ b/apps/coordinator/ts/deployer/__tests__/deployer.controller.test.ts
@@ -1,7 +1,8 @@
+import { ESupportedChains } from "@maci-protocol/sdk";
 import { Test } from "@nestjs/testing";
 import { zeroAddress } from "viem";
 
-import { ErrorCodes, ESupportedNetworks } from "../../common";
+import { ErrorCodes } from "../../common";
 import { DeployerController } from "../deployer.controller";
 import { DeployerService } from "../deployer.service";
 
@@ -50,7 +51,7 @@ describe("DeployerController", () => {
   describe("v1/deploy/maci", () => {
     test("should deploy all contracts", async () => {
       const { address } = await deployerController.deployMACIContracts({
-        chain: ESupportedNetworks.OPTIMISM_SEPOLIA,
+        chain: ESupportedChains.OptimismSepolia,
         approval,
         sessionKeyAddress,
         config: testMaciDeploymentConfig,
@@ -66,7 +67,7 @@ describe("DeployerController", () => {
 
       await expect(
         controller.deployMACIContracts({
-          chain: ESupportedNetworks.OPTIMISM_SEPOLIA,
+          chain: ESupportedChains.OptimismSepolia,
           approval: "0x123",
           sessionKeyAddress: "0x123",
           config: testMaciDeploymentConfig,
@@ -78,7 +79,7 @@ describe("DeployerController", () => {
   describe("v1/deploy/poll", () => {
     test("should deploy a new poll", async () => {
       const { pollId } = await deployerController.deployPoll({
-        chain: ESupportedNetworks.OPTIMISM_SEPOLIA,
+        chain: ESupportedChains.OptimismSepolia,
         approval,
         sessionKeyAddress,
         config: testPollDeploymentConfig,
@@ -94,7 +95,7 @@ describe("DeployerController", () => {
 
       await expect(
         controller.deployPoll({
-          chain: ESupportedNetworks.OPTIMISM_SEPOLIA,
+          chain: ESupportedChains.OptimismSepolia,
           approval: "0x123",
           sessionKeyAddress: "0x123",
           config: testPollDeploymentConfig,

--- a/apps/coordinator/ts/deployer/__tests__/deployer.service.test.ts
+++ b/apps/coordinator/ts/deployer/__tests__/deployer.service.test.ts
@@ -14,12 +14,13 @@ import {
   EInitialVoiceCreditProxiesFactories,
   EPolicies,
   EPolicyFactories,
+  ESupportedChains,
 } from "@maci-protocol/sdk";
 import dotenv from "dotenv";
 import { type Signer } from "ethers";
 import { zeroAddress } from "viem";
 
-import { ErrorCodes, ESupportedNetworks } from "../../common";
+import { ErrorCodes } from "../../common";
 import { FileService } from "../../file/file.service";
 import { SessionKeysService } from "../../sessionKeys/sessionKeys.service";
 import { DeployerService } from "../deployer.service";
@@ -45,7 +46,7 @@ jest.mock("@maci-protocol/sdk", (): unknown => ({
 }));
 
 describe("DeployerService", () => {
-  const chain = ESupportedNetworks.OPTIMISM_SEPOLIA;
+  const chain = ESupportedChains.OptimismSepolia;
   const signer = {
     getAddress: jest.fn().mockResolvedValue(zeroAddress),
   } as unknown as Signer;

--- a/apps/coordinator/ts/deployer/deployer.service.ts
+++ b/apps/coordinator/ts/deployer/deployer.service.ts
@@ -57,12 +57,13 @@ import {
   deployConstantInitialVoiceCreditProxyFactory,
   ConstantInitialVoiceCreditProxyFactory,
   EInitialVoiceCreditProxiesFactories,
+  ESupportedChains,
 } from "@maci-protocol/sdk";
 import { Injectable } from "@nestjs/common";
 import { BaseContract, Signer } from "ethers";
 import { type Hex } from "viem";
 
-import { ErrorCodes, ESupportedNetworks } from "../common";
+import { ErrorCodes } from "../common";
 import { getCoordinatorKeypair } from "../common/coordinatorKeypair";
 import { FileService } from "../file/file.service";
 import { SessionKeysService } from "../sessionKeys/sessionKeys.service";
@@ -117,7 +118,7 @@ export class DeployerService {
    */
   async deployAndSavePolicy(
     signer: Signer,
-    network: ESupportedNetworks,
+    network: ESupportedChains,
     policyConfig: IDeployPolicyConfig,
   ): Promise<BasePolicy> {
     let policyContract: BasePolicy;
@@ -427,7 +428,7 @@ export class DeployerService {
   async deployAndSaveVoiceCreditProxyFactory(
     signer: Signer,
     voiceCreditProxyFactoryType: EInitialVoiceCreditProxiesFactories,
-    network: ESupportedNetworks,
+    network: ESupportedChains,
   ): Promise<ConstantInitialVoiceCreditProxyFactory> {
     let contract: ConstantInitialVoiceCreditProxyFactory;
 
@@ -464,7 +465,7 @@ export class DeployerService {
   async deployAndSaveVoiceCreditProxy(
     signer: Signer,
     voiceCreditProxyType: EInitialVoiceCreditProxies,
-    network: ESupportedNetworks,
+    network: ESupportedChains,
     initialVoiceCreditProxyFactory: ConstantInitialVoiceCreditProxyFactory,
     args?: IInitialVoiceCreditProxyArgs,
   ): Promise<ConstantInitialVoiceCreditProxy> {

--- a/apps/coordinator/ts/deployer/dto.ts
+++ b/apps/coordinator/ts/deployer/dto.ts
@@ -1,10 +1,9 @@
+import { ESupportedChains } from "@maci-protocol/sdk";
 import { ApiProperty } from "@nestjs/swagger";
 import { IsEnum, IsOptional, IsString } from "class-validator";
 
 import type { IDeployMaciConfig, IDeployPollConfig } from "./types";
 import type { Hex } from "viem";
-
-import { ESupportedNetworks } from "../common";
 
 /**
  * Data transfer object for MACI contracts deployment
@@ -39,10 +38,10 @@ export class DeployerServiceDeployMaciDto {
    */
   @ApiProperty({
     description: "Chain to which to deploy the contract(s)",
-    enum: ESupportedNetworks,
+    enum: ESupportedChains,
   })
-  @IsEnum(ESupportedNetworks)
-  chain!: ESupportedNetworks;
+  @IsEnum(ESupportedChains)
+  chain!: ESupportedChains;
 
   /**
    * Config
@@ -87,10 +86,10 @@ export class DeployerServiceDeployPollDto {
    */
   @ApiProperty({
     description: "Chain to which to deploy the contract(s)",
-    enum: ESupportedNetworks,
+    enum: ESupportedChains,
   })
-  @IsEnum(ESupportedNetworks)
-  chain!: ESupportedNetworks;
+  @IsEnum(ESupportedChains)
+  chain!: ESupportedChains;
 
   /**
    * Config

--- a/apps/coordinator/ts/deployer/types.ts
+++ b/apps/coordinator/ts/deployer/types.ts
@@ -1,9 +1,13 @@
-import { EPolicies, EInitialVoiceCreditProxies, EMode, EInitialVoiceCreditProxiesFactories } from "@maci-protocol/sdk";
+import {
+  EPolicies,
+  EInitialVoiceCreditProxies,
+  EMode,
+  EInitialVoiceCreditProxiesFactories,
+  ESupportedChains,
+} from "@maci-protocol/sdk";
 import { SendUserOperationParameters } from "viem/account-abstraction";
 
 import type { Abi, Hex } from "viem";
-
-import { ESupportedNetworks } from "../common";
 
 /**
  * IDeployMACIArgs represents the arguments for deploying MACI
@@ -22,7 +26,7 @@ export interface IDeployMaciArgs {
   /**
    * The chain name
    */
-  chain: ESupportedNetworks;
+  chain: ESupportedChains;
 
   /**
    * The configuration for deploying MACI
@@ -47,7 +51,7 @@ export interface IDeployPollArgs {
   /**
    * The chain name
    */
-  chain: ESupportedNetworks;
+  chain: ESupportedChains;
 
   /**
    * The configuration for deploying a poll

--- a/apps/coordinator/ts/health/__tests__/health.controller.test.ts
+++ b/apps/coordinator/ts/health/__tests__/health.controller.test.ts
@@ -1,6 +1,6 @@
+import { ESupportedChains } from "@maci-protocol/sdk";
 import { zeroAddress } from "viem";
 
-import { ESupportedNetworks } from "../../common";
 import { HealthController } from "../health.controller";
 import { HealthService } from "../health.service";
 
@@ -25,7 +25,7 @@ describe("HealthController", () => {
         fundsInNetworks: [
           {
             address: zeroAddress.replace("0x0", "0x1"),
-            network: ESupportedNetworks.ETHEREUM,
+            network: ESupportedChains.Mainnet,
             balance: "0",
             status: true,
           },

--- a/apps/coordinator/ts/health/health.service.ts
+++ b/apps/coordinator/ts/health/health.service.ts
@@ -1,4 +1,4 @@
-import { EMode } from "@maci-protocol/sdk";
+import { EMode, ESupportedChains } from "@maci-protocol/sdk";
 import { Injectable } from "@nestjs/common";
 import { formatEther } from "ethers";
 import { zeroAddress } from "viem";
@@ -8,7 +8,7 @@ import path from "path";
 
 import type { ICheckRapidsnark, ICheckWalletFunds, ICheckZkeysDirectory, IHealthCheckResponse } from "./types";
 
-import { ESupportedNetworks, getSigner } from "../common";
+import { getSigner } from "../common";
 import { FileService } from "../file/file.service";
 import { RedisService } from "../redis/redis.service";
 
@@ -121,7 +121,7 @@ export class HealthService {
    * @returns the address and its funds in all networks
    */
   async checkWalletFunds(): Promise<ICheckWalletFunds> {
-    const networks = Object.values(ESupportedNetworks);
+    const networks = Object.values(ESupportedChains);
 
     const fundsInNetworks = await Promise.all(
       networks.map(async (network) => {

--- a/apps/coordinator/ts/jest/__mocks__/@excubiae/contracts.ts
+++ b/apps/coordinator/ts/jest/__mocks__/@excubiae/contracts.ts
@@ -1,0 +1,3 @@
+// Mock for @excubiae/contracts to avoid Hardhat Ignition dependency issues in tests
+export const getProxyContract = jest.fn();
+export const deployProxyClone = jest.fn();

--- a/apps/coordinator/ts/jest/__mocks__/@openzeppelin/merkle-tree.ts
+++ b/apps/coordinator/ts/jest/__mocks__/@openzeppelin/merkle-tree.ts
@@ -1,0 +1,18 @@
+// Mock for @openzeppelin/merkle-tree to avoid util.deprecate issues in tests
+export class StandardMerkleTree {
+  static of = jest.fn();
+
+  static from = jest.fn();
+
+  static verify = jest.fn();
+
+  static load = jest.fn();
+
+  getProof = jest.fn();
+
+  verify = jest.fn();
+
+  render = jest.fn();
+
+  dump = jest.fn();
+}

--- a/apps/coordinator/ts/proof/__tests__/proof.controller.test.ts
+++ b/apps/coordinator/ts/proof/__tests__/proof.controller.test.ts
@@ -1,11 +1,10 @@
-import { EMode, type ITallyData } from "@maci-protocol/sdk";
+import { EMode, ESupportedChains, type ITallyData } from "@maci-protocol/sdk";
 import { HttpException, HttpStatus } from "@nestjs/common";
 import { Test } from "@nestjs/testing";
 
 import type { IGetPublicKeyData } from "../../file/types";
 import type { IGenerateArgs, IGenerateData, IMergeArgs } from "../types";
 
-import { ESupportedNetworks } from "../../common";
 import { FileService } from "../../file/file.service";
 import { ProofController } from "../proof.controller";
 import { ProofGeneratorService } from "../proof.service";
@@ -19,7 +18,7 @@ describe("ProofController", () => {
     mode: EMode.NON_QV,
     sessionKeyAddress: "0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
     approval: "0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
-    chain: ESupportedNetworks.LOCALHOST,
+    chain: ESupportedChains.Localhost,
   };
 
   const defaultMergeArgs: IMergeArgs = {
@@ -27,7 +26,7 @@ describe("ProofController", () => {
     pollId: 0,
     sessionKeyAddress: "0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
     approval: "0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
-    chain: ESupportedNetworks.LOCALHOST,
+    chain: ESupportedChains.Localhost,
   };
 
   const defaultProofGeneratorData: IGenerateData = {

--- a/apps/coordinator/ts/proof/__tests__/proof.gateway.test.ts
+++ b/apps/coordinator/ts/proof/__tests__/proof.gateway.test.ts
@@ -1,10 +1,9 @@
-import { type ITallyData, type IGenerateProofsOptions, EMode } from "@maci-protocol/sdk";
+import { type ITallyData, type IGenerateProofsOptions, EMode, ESupportedChains } from "@maci-protocol/sdk";
 import { Test } from "@nestjs/testing";
 import { Server } from "socket.io";
 
 import type { IGenerateArgs, IGenerateData } from "../types";
 
-import { ESupportedNetworks } from "../../common";
 import { ProofGateway } from "../proof.gateway";
 import { ProofGeneratorService } from "../proof.service";
 import { EProofGenerationEvents } from "../types";
@@ -18,7 +17,7 @@ describe("ProofGateway", () => {
     mode: EMode.NON_QV,
     sessionKeyAddress: "0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
     approval: "0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
-    chain: ESupportedNetworks.LOCALHOST,
+    chain: ESupportedChains.Localhost,
   };
 
   const defaultProofGeneratorData: IGenerateData = {

--- a/apps/coordinator/ts/proof/__tests__/proof.service.test.ts
+++ b/apps/coordinator/ts/proof/__tests__/proof.service.test.ts
@@ -1,11 +1,11 @@
 import { Keypair, PrivateKey } from "@maci-protocol/domainobjs";
-import { Deployment, EMode } from "@maci-protocol/sdk";
+import { Deployment, EMode, ESupportedChains } from "@maci-protocol/sdk";
 import dotenv from "dotenv";
 import { zeroAddress } from "viem";
 
 import type { IGenerateArgs } from "../types";
 
-import { ErrorCodes, ESupportedNetworks } from "../../common";
+import { ErrorCodes } from "../../common";
 import { getCoordinatorKeypair } from "../../common/coordinatorKeypair";
 import { FileService } from "../../file/file.service";
 import { SessionKeysService } from "../../sessionKeys/sessionKeys.service";
@@ -55,7 +55,7 @@ describe("ProofGeneratorService", () => {
       poll: 1,
       maciContractAddress: zeroAddress,
       mode: EMode.NON_QV,
-      chain: ESupportedNetworks.OPTIMISM_SEPOLIA,
+      chain: ESupportedChains.OptimismSepolia,
     };
   });
 

--- a/apps/coordinator/ts/proof/dto.ts
+++ b/apps/coordinator/ts/proof/dto.ts
@@ -1,10 +1,8 @@
-import { EMode } from "@maci-protocol/sdk";
+import { ESupportedChains, EMode } from "@maci-protocol/sdk";
 import { ApiProperty } from "@nestjs/swagger";
 import { IsEnum, IsEthereumAddress, IsInt, IsOptional, IsString, Max, Min } from "class-validator";
 
 import type { Hex } from "viem";
-
-import { ESupportedNetworks } from "../common";
 
 /**
  * Data transfer object for generate proof
@@ -106,10 +104,10 @@ export class GenerateProofDto {
    */
   @ApiProperty({
     description: "Chain to which to deploy the contract(s)",
-    enum: ESupportedNetworks,
+    enum: ESupportedChains,
   })
-  @IsEnum(ESupportedNetworks)
-  chain!: ESupportedNetworks;
+  @IsEnum(ESupportedChains)
+  chain!: ESupportedChains;
 }
 
 /**
@@ -158,10 +156,10 @@ export class MergeTreesDto {
    */
   @ApiProperty({
     description: "Chain to which to deploy the contract(s)",
-    enum: ESupportedNetworks,
+    enum: ESupportedChains,
   })
-  @IsEnum(ESupportedNetworks)
-  chain!: ESupportedNetworks;
+  @IsEnum(ESupportedChains)
+  chain!: ESupportedChains;
 }
 
 /**
@@ -210,8 +208,8 @@ export class SubmitProofsDto {
    */
   @ApiProperty({
     description: "Chain to which to deploy the contract(s)",
-    enum: ESupportedNetworks,
+    enum: ESupportedChains,
   })
-  @IsEnum(ESupportedNetworks)
-  chain!: ESupportedNetworks;
+  @IsEnum(ESupportedChains)
+  chain!: ESupportedChains;
 }

--- a/apps/coordinator/ts/proof/types.ts
+++ b/apps/coordinator/ts/proof/types.ts
@@ -1,7 +1,5 @@
-import type { ITallyData, IProof, EMode } from "@maci-protocol/sdk";
+import type { ITallyData, IProof, EMode, ESupportedChains } from "@maci-protocol/sdk";
 import type { Hex } from "viem";
-
-import { ESupportedNetworks } from "../common";
 
 /**
  * WS events for proof generation
@@ -45,7 +43,7 @@ export interface IGenerateArgs {
   /**
    * Chain
    */
-  chain: ESupportedNetworks;
+  chain: ESupportedChains;
 
   /**
    * Poll id
@@ -145,7 +143,7 @@ export interface IMergeArgs {
   /**
    * Chain
    */
-  chain: ESupportedNetworks;
+  chain: ESupportedChains;
 }
 
 /**
@@ -175,5 +173,5 @@ export interface ISubmitProofsArgs {
   /**
    * Chain
    */
-  chain: ESupportedNetworks;
+  chain: ESupportedChains;
 }

--- a/apps/coordinator/ts/redis/__tests__/redis.service.test.ts
+++ b/apps/coordinator/ts/redis/__tests__/redis.service.test.ts
@@ -1,7 +1,6 @@
-import { EMode } from "@maci-protocol/sdk";
+import { ESupportedChains, EMode } from "@maci-protocol/sdk";
 import { createClient, RedisArgument, RedisClientType } from "@redis/client";
 
-import { ESupportedNetworks } from "../../common";
 import { RedisService } from "../redis.service";
 import { IScheduledPoll } from "../types";
 import { getPollKeyFromObject } from "../utils";
@@ -12,7 +11,7 @@ const scheduledPoll: IScheduledPoll = {
   maciAddress: "0xb83074Ac11fc569AC12F1b7D0C0a6809c3dc355b",
   pollId: "5",
   mode: EMode.NON_QV,
-  chain: ESupportedNetworks.OPTIMISM_SEPOLIA,
+  chain: ESupportedChains.OptimismSepolia,
   endDate: 1752534000,
   deploymentBlockNumber: 1,
   merged: false,

--- a/apps/coordinator/ts/redis/types.ts
+++ b/apps/coordinator/ts/redis/types.ts
@@ -1,5 +1,4 @@
-import type { ESupportedNetworks } from "../common";
-import type { EMode } from "@maci-protocol/sdk";
+import type { EMode, ESupportedChains } from "@maci-protocol/sdk";
 
 /**
  * Interface of the minimal properties to identify a scheduled poll
@@ -18,7 +17,7 @@ export interface IIdentityScheduledPoll {
   /**
    * Chain in which the poll is deployed
    */
-  chain: ESupportedNetworks;
+  chain: ESupportedChains;
 }
 
 /**

--- a/apps/coordinator/ts/scheduler/__tests__/scheduler.controller.test.ts
+++ b/apps/coordinator/ts/scheduler/__tests__/scheduler.controller.test.ts
@@ -1,7 +1,6 @@
-import { EMode } from "@maci-protocol/sdk";
+import { EMode, ESupportedChains } from "@maci-protocol/sdk";
 import { HttpException, HttpStatus } from "@nestjs/common";
 
-import { ESupportedNetworks } from "../../common";
 import { IdentityScheduledPollDto, SchedulePollWithSignerDto } from "../dto";
 import { SchedulerController } from "../scheduler.controller";
 import { SchedulerService } from "../scheduler.service";
@@ -10,7 +9,7 @@ const scheduledPoll: SchedulePollWithSignerDto = {
   maciAddress: "0x0",
   pollId: 5,
   mode: EMode.NON_QV,
-  chain: ESupportedNetworks.OPTIMISM_SEPOLIA,
+  chain: ESupportedChains.OptimismSepolia,
   deploymentBlockNumber: 1,
 };
 

--- a/apps/coordinator/ts/scheduler/__tests__/scheduler.service.test.ts
+++ b/apps/coordinator/ts/scheduler/__tests__/scheduler.service.test.ts
@@ -1,9 +1,9 @@
-import { EMode, getPoll, isTallied } from "@maci-protocol/sdk";
+import { EMode, ESupportedChains, getPoll, isTallied } from "@maci-protocol/sdk";
 import { SchedulerRegistry } from "@nestjs/schedule";
 
 import type { IScheduledPoll } from "../../redis/types";
 
-import { ErrorCodes, ESupportedNetworks } from "../../common";
+import { ErrorCodes } from "../../common";
 import { FileService } from "../../file/file.service";
 import { RedisService } from "../../redis/redis.service";
 import { getPollKeyFromObject } from "../../redis/utils";
@@ -14,7 +14,7 @@ const scheduledPoll: IScheduledPoll = {
   maciAddress: "0x0",
   pollId: "5",
   mode: EMode.NON_QV,
-  chain: ESupportedNetworks.OPTIMISM_SEPOLIA,
+  chain: ESupportedChains.OptimismSepolia,
   endDate: 1752534000,
   deploymentBlockNumber: 1,
   merged: false,

--- a/apps/coordinator/ts/scheduler/dto.ts
+++ b/apps/coordinator/ts/scheduler/dto.ts
@@ -1,10 +1,8 @@
-import { EMode } from "@maci-protocol/sdk";
+import { EMode, ESupportedChains } from "@maci-protocol/sdk";
 import { ApiProperty } from "@nestjs/swagger";
 import { IsEnum, IsEthereumAddress, IsInt, IsOptional, IsString, Min } from "class-validator";
 
 import type { Hex } from "viem";
-
-import { ESupportedNetworks } from "../common";
 
 /**
  * Data transfer object for scheduled poll
@@ -37,10 +35,10 @@ export class IdentityScheduledPollDto {
    */
   @ApiProperty({
     description: "Chain to which to deploy the contract(s)",
-    enum: ESupportedNetworks,
+    enum: ESupportedChains,
   })
-  @IsEnum(ESupportedNetworks)
-  chain!: ESupportedNetworks;
+  @IsEnum(ESupportedChains)
+  chain!: ESupportedChains;
 }
 
 /**

--- a/apps/coordinator/ts/sessionKeys/__tests__/sessionKeys.service.test.ts
+++ b/apps/coordinator/ts/sessionKeys/__tests__/sessionKeys.service.test.ts
@@ -1,8 +1,9 @@
+import { ESupportedChains } from "@maci-protocol/sdk";
 import { createKernelAccount, createKernelAccountClient } from "@zerodev/sdk";
 import dotenv from "dotenv";
 import { zeroAddress } from "viem";
 
-import { ErrorCodes, ESupportedNetworks } from "../../common";
+import { ErrorCodes } from "../../common";
 import { FileService } from "../../file/file.service";
 import { SessionKeysService } from "../sessionKeys.service";
 
@@ -78,7 +79,7 @@ describe("SessionKeysService", () => {
         sessionKeysService.generateClientFromSessionKey(
           sessionKeyAddress.sessionKeyAddress,
           "0xinvalid",
-          ESupportedNetworks.OPTIMISM_SEPOLIA,
+          ESupportedChains.OptimismSepolia,
         ),
       ).rejects.toThrow(ErrorCodes.INVALID_APPROVAL.toString());
     });
@@ -88,7 +89,7 @@ describe("SessionKeysService", () => {
 
       const approval = await generateApproval(zeroAddress);
       await expect(
-        sessionKeysService.generateClientFromSessionKey(zeroAddress, approval, ESupportedNetworks.OPTIMISM_SEPOLIA),
+        sessionKeysService.generateClientFromSessionKey(zeroAddress, approval, ESupportedChains.OptimismSepolia),
       ).rejects.toThrow(ErrorCodes.SESSION_KEY_NOT_FOUND.toString());
     });
 
@@ -100,7 +101,7 @@ describe("SessionKeysService", () => {
       const client = await sessionKeysService.generateClientFromSessionKey(
         sessionKeyAddress,
         approval,
-        ESupportedNetworks.OPTIMISM_SEPOLIA,
+        ESupportedChains.OptimismSepolia,
       );
 
       expect(createKernelAccountClient).toHaveBeenCalledTimes(1);

--- a/apps/coordinator/ts/sessionKeys/__tests__/utils.ts
+++ b/apps/coordinator/ts/sessionKeys/__tests__/utils.ts
@@ -1,3 +1,4 @@
+import { ESupportedChains } from "@maci-protocol/sdk";
 import { signerToEcdsaValidator } from "@zerodev/ecdsa-validator";
 import { type Policy, serializePermissionAccount, toPermissionValidator } from "@zerodev/permissions";
 import { toSudoPolicy, toTimestampPolicy } from "@zerodev/permissions/policies";
@@ -8,7 +9,6 @@ import dotenv from "dotenv";
 import { type Hex } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 
-import { ESupportedNetworks } from "../../common";
 import { getPublicClient } from "../../common/accountAbstraction";
 
 dotenv.config();
@@ -34,7 +34,7 @@ export const generateTimestampPolicy = (endTime: number, start?: number): Policy
  * @returns - the kernel account
  */
 export const getKernelAccount = async (sessionKeyAddress: Hex): Promise<CreateKernelAccountReturnType> => {
-  const publicClient = await getPublicClient(ESupportedNetworks.OPTIMISM_SEPOLIA);
+  const publicClient = await getPublicClient(ESupportedChains.OptimismSepolia);
 
   const sessionKeySigner = privateKeyToAccount(process.env.PRIVATE_KEY! as Hex);
   const ecdsaValidator = await signerToEcdsaValidator(publicClient, {

--- a/apps/coordinator/ts/sessionKeys/sessionKeys.service.ts
+++ b/apps/coordinator/ts/sessionKeys/sessionKeys.service.ts
@@ -4,9 +4,10 @@ import { BrowserProvider, Signer } from "ethers";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 
 import type { AASigner } from "@maci-protocol/contracts";
+import type { ESupportedChains } from "@maci-protocol/sdk";
 import type { Hex } from "viem";
 
-import { ErrorCodes, ESupportedNetworks, getSigner, KernelClientType } from "../common";
+import { ErrorCodes, getSigner, KernelClientType } from "../common";
 import { getKernelClient } from "../common/accountAbstraction";
 import { FileService } from "../file/file.service";
 
@@ -65,7 +66,7 @@ export class SessionKeysService {
   async generateClientFromSessionKey(
     sessionKeyAddress: Hex,
     approval: string,
-    chain: ESupportedNetworks,
+    chain: ESupportedChains,
   ): Promise<KernelClientType> {
     // retrieve the session key from the file service
     const sessionKey = this.fileService.getSessionKey(sessionKeyAddress);
@@ -109,7 +110,7 @@ export class SessionKeysService {
    * @returns a signer
    */
   async getCoordinatorSigner(
-    chain: ESupportedNetworks,
+    chain: ESupportedChains,
     sessionKeyAddress?: Hex,
     approval?: string,
   ): Promise<AASigner | Signer> {

--- a/apps/coordinator/ts/subgraph/__tests__/subgraph.controller.test.ts
+++ b/apps/coordinator/ts/subgraph/__tests__/subgraph.controller.test.ts
@@ -1,9 +1,9 @@
+import { ESupportedChains } from "@maci-protocol/sdk";
 import { HttpException, HttpStatus } from "@nestjs/common";
 import { Test } from "@nestjs/testing";
 
 import type { IDeploySubgraphArgs, IDeploySubgraphReturn } from "../types";
 
-import { ESupportedNetworks } from "../../common";
 import { SubgraphController } from "../subgraph.controller";
 import { SubgraphService } from "../subgraph.service";
 
@@ -13,7 +13,7 @@ describe("SubgraphController", () => {
   const defaultSubgraphDeployArgs: IDeploySubgraphArgs = {
     maciContractAddress: "0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
     startBlock: 0,
-    network: ESupportedNetworks.OPTIMISM_SEPOLIA,
+    network: ESupportedChains.OptimismSepolia,
     name: "subgraph",
     tag: "v0.0.1",
   };

--- a/apps/coordinator/ts/subgraph/__tests__/subgraph.gateway.test.ts
+++ b/apps/coordinator/ts/subgraph/__tests__/subgraph.gateway.test.ts
@@ -1,7 +1,7 @@
+import { ESupportedChains } from "@maci-protocol/sdk";
 import { Test } from "@nestjs/testing";
 import { Server } from "socket.io";
 
-import { ESupportedNetworks } from "../../common";
 import { SubgraphGateway } from "../subgraph.gateway";
 import { SubgraphService } from "../subgraph.service";
 import {
@@ -19,7 +19,7 @@ describe("SubgraphGateway", () => {
   const defaultSubgraphDeployArgs: IDeploySubgraphArgs = {
     maciContractAddress: "0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
     startBlock: 0,
-    network: ESupportedNetworks.OPTIMISM_SEPOLIA,
+    network: ESupportedChains.OptimismSepolia,
     name: "subgraph",
     tag: "v0.0.1",
   };

--- a/apps/coordinator/ts/subgraph/__tests__/subgraph.service.test.ts
+++ b/apps/coordinator/ts/subgraph/__tests__/subgraph.service.test.ts
@@ -1,3 +1,4 @@
+import { ESupportedChains } from "@maci-protocol/sdk";
 import dotenv from "dotenv";
 
 import childProcess from "child_process";
@@ -5,7 +6,7 @@ import fs from "fs";
 
 import type { IDeploySubgraphArgs } from "../types";
 
-import { ErrorCodes, ESupportedNetworks } from "../../common";
+import { ErrorCodes } from "../../common";
 import { SubgraphService } from "../subgraph.service";
 
 dotenv.config();
@@ -30,7 +31,7 @@ describe("SubgraphService", () => {
   const defaultArgs: IDeploySubgraphArgs = {
     maciContractAddress: "0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
     startBlock: 0,
-    network: ESupportedNetworks.OPTIMISM_SEPOLIA,
+    network: ESupportedChains.OptimismSepolia,
     name: "subgraph",
     tag: "v0.0.1",
   };
@@ -58,7 +59,7 @@ describe("SubgraphService", () => {
   test("should throw error if network is invalid", async () => {
     const service = new SubgraphService();
 
-    await expect(service.deploy({ ...defaultArgs, network: "unknown" as ESupportedNetworks })).rejects.toThrow(
+    await expect(service.deploy({ ...defaultArgs, network: "unknown" as ESupportedChains })).rejects.toThrow(
       ErrorCodes.UNSUPPORTED_NETWORK.toString(),
     );
   });

--- a/apps/coordinator/ts/subgraph/dto.ts
+++ b/apps/coordinator/ts/subgraph/dto.ts
@@ -1,7 +1,6 @@
+import { ESupportedChains } from "@maci-protocol/sdk";
 import { ApiProperty } from "@nestjs/swagger";
 import { IsEnum, IsEthereumAddress, IsInt, IsString, Matches, MaxLength, Min, MinLength } from "class-validator";
-
-import { ESupportedNetworks } from "../common";
 
 /**
  * Data transfer object for deploying subgraph
@@ -34,10 +33,10 @@ export class DeploySubgraphDto {
    */
   @ApiProperty({
     description: "Network CLI name (https://thegraph.com/docs/en/developing/supported-networks/)",
-    enum: ESupportedNetworks,
+    enum: ESupportedChains,
   })
-  @IsEnum(ESupportedNetworks)
-  network!: ESupportedNetworks;
+  @IsEnum(ESupportedChains)
+  network!: ESupportedChains;
 
   /**
    * Subgraph name

--- a/apps/coordinator/ts/subgraph/subgraph.service.ts
+++ b/apps/coordinator/ts/subgraph/subgraph.service.ts
@@ -1,3 +1,4 @@
+import { ESupportedChains } from "@maci-protocol/sdk";
 import { Injectable, Logger } from "@nestjs/common";
 
 import childProcess from "child_process";
@@ -5,7 +6,7 @@ import fs from "fs";
 import path from "path";
 import { promisify } from "util";
 
-import { ErrorCodes, ESupportedNetworks } from "../common";
+import { ErrorCodes } from "../common";
 
 import {
   EProgressStep,
@@ -46,7 +47,7 @@ export class SubgraphService {
    */
   async deploy(args: IDeploySubgraphArgs, options?: ISubgraphWsHooks): Promise<IDeploySubgraphReturn> {
     try {
-      if (!Object.values(ESupportedNetworks).includes(args.network)) {
+      if (!Object.values(ESupportedChains).includes(args.network)) {
         throw new Error(ErrorCodes.UNSUPPORTED_NETWORK.toString());
       }
 

--- a/apps/coordinator/ts/subgraph/types.ts
+++ b/apps/coordinator/ts/subgraph/types.ts
@@ -1,4 +1,4 @@
-import type { ESupportedNetworks } from "../common";
+import { ESupportedChains } from "@maci-protocol/sdk";
 
 /**
  * WS events for subgraph
@@ -27,7 +27,7 @@ export interface IDeploySubgraphArgs {
   /**
    * Network
    */
-  network: ESupportedNetworks;
+  network: ESupportedChains;
 
   /**
    * Subgraph name

--- a/packages/contracts/tasks/helpers/constants.ts
+++ b/packages/contracts/tasks/helpers/constants.ts
@@ -44,6 +44,7 @@ export enum ESupportedChains {
   PolygonCardonaZkEvm = "polygon_cardona_zkevm",
   Coverage = "coverage",
   Hardhat = "hardhat",
+  Localhost = "localhost",
 }
 
 /**
@@ -123,6 +124,7 @@ export const getNetworkRpcUrls = (): Record<ESupportedChains, string> => {
     [ESupportedChains.PolygonCardonaZkEvm]: POLYGON_CARDONA_RPC_URL,
     [ESupportedChains.Coverage]: "http://localhost:8555",
     [ESupportedChains.Hardhat]: "http://localhost:8545",
+    [ESupportedChains.Localhost]: "http://localhost:8545",
     [ESupportedChains.Mainnet]: MAINNET_RPC_URL,
   };
 };

--- a/packages/sdk/ts/index.ts
+++ b/packages/sdk/ts/index.ts
@@ -21,6 +21,7 @@ export {
   EInitialVoiceCreditProxies,
   EInitialVoiceCreditProxiesFactories,
   EDeploySteps,
+  ESupportedChains,
   Deployment,
   ContractStorage,
   ProofGenerator,


### PR DESCRIPTION
# Description
Duplicate of #2653

1. Export `ESupportedChains` to be used in different apps (e.g. coordinator).
2. Adapt coodinator to use `ESupportedChains` instead of the local `ESupportedNetworks`

Special thanks to @ultraviolet10 for helping out 

## Related issue(s)

Closes #2510

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I ran and verified that all tests pass according to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
