### PR TITLE
fix(coordinator): modify getAll to return keys and values

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -98,6 +98,7 @@ module.exports = {
     "@typescript-eslint/use-unknown-in-catch-callback-variable": "off",
     "@typescript-eslint/no-explicit-any": "error",
     "@typescript-eslint/explicit-module-boundary-types": "error",
+    "@typescript-eslint/consistent-type-imports": ["warn", { fixStyle: "inline-type-imports" }],
     "@typescript-eslint/no-use-before-define": ["error", { functions: false, classes: false }],
     "@typescript-eslint/no-misused-promises": ["error", { checksVoidReturn: false }],
     "@typescript-eslint/no-shadow": [

--- a/apps/coordinator/tests/e2e.redis.test.ts
+++ b/apps/coordinator/tests/e2e.redis.test.ts
@@ -1,8 +1,8 @@
 import { EMode, ESupportedChains } from "@maci-protocol/sdk";
-import { createClient, RedisClientType } from "@redis/client";
+import { createClient, type RedisClientType } from "@redis/client";
 
 import { RedisService } from "../ts/redis/redis.service";
-import { IScheduledPoll } from "../ts/redis/types";
+import { type IScheduledPoll } from "../ts/redis/types";
 import { getPollKeyFromObject } from "../ts/redis/utils";
 
 const REDIS__GET_ALL_PREFIX = "*-test";
@@ -37,9 +37,7 @@ describe("RedisService", () => {
     // Clean up after each test
     const keys = await redisClient.keys(REDIS__GET_ALL_PREFIX);
 
-    if (keys.length) {
-      await redisClient.del(keys);
-    }
+    await Promise.all(keys.map((key) => redisClient.del(key)));
   });
 
   afterAll(async () => {

--- a/apps/coordinator/ts/redis/__tests__/redis.service.test.ts
+++ b/apps/coordinator/ts/redis/__tests__/redis.service.test.ts
@@ -1,8 +1,8 @@
 import { ESupportedChains, EMode } from "@maci-protocol/sdk";
-import { createClient, RedisArgument, RedisClientType } from "@redis/client";
+import { createClient, type RedisArgument, type RedisClientType } from "@redis/client";
 
 import { RedisService } from "../redis.service";
-import { IScheduledPoll } from "../types";
+import { type IScheduledPoll } from "../types";
 import { getPollKeyFromObject } from "../utils";
 
 const REDIS__GET_ALL_PREFIX = "*-test";

--- a/apps/coordinator/ts/redis/redis.service.ts
+++ b/apps/coordinator/ts/redis/redis.service.ts
@@ -1,6 +1,8 @@
 import { Injectable, OnModuleInit } from "@nestjs/common";
 import { createClient, RedisClientType } from "@redis/client";
 
+import { IGetAllSingleObject } from "./types";
+
 /**
  * Redis service to interact with the Redis database.
  */
@@ -58,8 +60,8 @@ export class RedisService implements OnModuleInit {
    * @dev if no match is provided, it will return all keys
    * @returns the array of string values stored in Redis that match the pattern
    */
-  async getAll(match?: string): Promise<string[]> {
-    let result: string[] = [];
+  async getAll(match?: string): Promise<IGetAllSingleObject[]> {
+    let result: IGetAllSingleObject[] = [];
     let currentCursor = "0";
 
     do {
@@ -69,7 +71,12 @@ export class RedisService implements OnModuleInit {
 
       // eslint-disable-next-line no-await-in-loop
       const values = await Promise.all(keys.map((key) => this.get(key)));
-      result = result.concat(values.filter((value) => value !== null));
+
+      result = result.concat(
+        values
+          .map((value, index) => ({ key: keys[index], value }))
+          .filter((item): item is IGetAllSingleObject => item.value !== null),
+      );
 
       currentCursor = cursor;
     } while (currentCursor !== "0");

--- a/apps/coordinator/ts/redis/types.ts
+++ b/apps/coordinator/ts/redis/types.ts
@@ -59,3 +59,18 @@ export interface IGetPollKeyForRedisParams extends IIdentityScheduledPoll {
    */
   test?: boolean;
 }
+
+/**
+ * Interface for getAll single object
+ */
+export interface IGetAllSingleObject {
+  /**
+   * The key of the object
+   */
+  key: string;
+
+  /**
+   * The value of the object
+   */
+  value: string;
+}

--- a/apps/coordinator/ts/scheduler/__tests__/scheduler.controller.test.ts
+++ b/apps/coordinator/ts/scheduler/__tests__/scheduler.controller.test.ts
@@ -1,9 +1,9 @@
 import { EMode, ESupportedChains } from "@maci-protocol/sdk";
 import { HttpException, HttpStatus } from "@nestjs/common";
 
-import { IdentityScheduledPollDto, SchedulePollWithSignerDto } from "../dto";
+import { type IdentityScheduledPollDto, type SchedulePollWithSignerDto } from "../dto";
 import { SchedulerController } from "../scheduler.controller";
-import { SchedulerService } from "../scheduler.service";
+import { type SchedulerService } from "../scheduler.service";
 
 const scheduledPoll: SchedulePollWithSignerDto = {
   maciAddress: "0x0",


### PR DESCRIPTION
# Description

1. Fix `getAll` to retrieve keys and values at the same time
2. Add eslint rule to automatically add `type` in type imports


## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [X] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [X] I ran and verified that all tests pass according to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
