### PR TITLE
chore: use type imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -98,7 +98,7 @@ module.exports = {
     "@typescript-eslint/use-unknown-in-catch-callback-variable": "off",
     "@typescript-eslint/no-explicit-any": "error",
     "@typescript-eslint/explicit-module-boundary-types": "error",
-    "@typescript-eslint/consistent-type-imports": ["warn", { fixStyle: "inline-type-imports" }],
+    "@typescript-eslint/consistent-type-imports": ["error", { fixStyle: "inline-type-imports" }],
     "@typescript-eslint/no-use-before-define": ["error", { functions: false, classes: false }],
     "@typescript-eslint/no-misused-promises": ["error", { checksVoidReturn: false }],
     "@typescript-eslint/no-shadow": [

--- a/.github/workflows/subgraph-build.yml
+++ b/.github/workflows/subgraph-build.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04 # ubuntu-24.04 is not supported yet
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v5

--- a/apps/coordinator/ts/auth/__tests__/AccountSignatureGuard.test.ts
+++ b/apps/coordinator/ts/auth/__tests__/AccountSignatureGuard.test.ts
@@ -1,11 +1,11 @@
-import { Reflector } from "@nestjs/core";
+import { type Reflector } from "@nestjs/core";
 import dotenv from "dotenv";
 import { getBytes, hashMessage } from "ethers";
 import hardhat from "hardhat";
 
 import type { ExecutionContext } from "@nestjs/common";
 
-import { CryptoService } from "../../crypto/crypto.service";
+import { type CryptoService } from "../../crypto/crypto.service";
 import { AccountSignatureGuard, PUBLIC_METADATA_KEY, Public } from "../AccountSignatureGuard.service";
 
 dotenv.config();

--- a/apps/coordinator/ts/common/types.ts
+++ b/apps/coordinator/ts/common/types.ts
@@ -1,5 +1,5 @@
-import { CreateKernelAccountReturnType, KernelAccountClient } from "@zerodev/sdk";
-import { BundlerClient } from "viem/account-abstraction";
+import { type CreateKernelAccountReturnType, type KernelAccountClient } from "@zerodev/sdk";
+import { type BundlerClient } from "viem/account-abstraction";
 
 import type { Chain, HttpTransport, PublicClient, Transport } from "viem";
 

--- a/apps/coordinator/ts/health/__tests__/health.controller.test.ts
+++ b/apps/coordinator/ts/health/__tests__/health.controller.test.ts
@@ -2,7 +2,7 @@ import { ESupportedChains } from "@maci-protocol/sdk";
 import { zeroAddress } from "viem";
 
 import { HealthController } from "../health.controller";
-import { HealthService } from "../health.service";
+import { type HealthService } from "../health.service";
 
 describe("HealthController", () => {
   const mockHealthService = {

--- a/apps/coordinator/ts/health/__tests__/health.service.test.ts
+++ b/apps/coordinator/ts/health/__tests__/health.service.test.ts
@@ -5,7 +5,7 @@ import { zeroAddress } from "viem";
 import fs, { type Stats } from "fs";
 
 import { FileService } from "../../file/file.service";
-import { RedisService } from "../../redis/redis.service";
+import { type RedisService } from "../../redis/redis.service";
 import { HealthService } from "../health.service";
 
 dotenv.config();

--- a/apps/coordinator/ts/proof/__tests__/proof.gateway.test.ts
+++ b/apps/coordinator/ts/proof/__tests__/proof.gateway.test.ts
@@ -1,6 +1,6 @@
 import { type ITallyData, type IGenerateProofsOptions, EMode, ESupportedChains } from "@maci-protocol/sdk";
 import { Test } from "@nestjs/testing";
-import { Server } from "socket.io";
+import { type Server } from "socket.io";
 
 import type { IGenerateArgs, IGenerateData } from "../types";
 

--- a/apps/coordinator/ts/sessionKeys/provider/KernelEIP1193Provider.ts
+++ b/apps/coordinator/ts/sessionKeys/provider/KernelEIP1193Provider.ts
@@ -1,4 +1,4 @@
-import { KernelAccountClient } from "@zerodev/sdk";
+import { type KernelAccountClient } from "@zerodev/sdk";
 import { safeCreateCallAddress } from "@zerodev/sdk/constants";
 import { encodeFunctionData, parseAbi } from "viem";
 

--- a/apps/coordinator/ts/subgraph/__tests__/subgraph.gateway.test.ts
+++ b/apps/coordinator/ts/subgraph/__tests__/subgraph.gateway.test.ts
@@ -1,6 +1,6 @@
 import { ESupportedChains } from "@maci-protocol/sdk";
 import { Test } from "@nestjs/testing";
-import { Server } from "socket.io";
+import { type Server } from "socket.io";
 
 import { SubgraphGateway } from "../subgraph.gateway";
 import { SubgraphService } from "../subgraph.service";

--- a/apps/coordinator/ts/subgraph/types.ts
+++ b/apps/coordinator/ts/subgraph/types.ts
@@ -1,4 +1,4 @@
-import { ESupportedChains } from "@maci-protocol/sdk";
+import { type ESupportedChains } from "@maci-protocol/sdk";
 
 /**
  * WS events for subgraph

--- a/apps/relayer/tests/messageBatches.test.ts
+++ b/apps/relayer/tests/messageBatches.test.ts
@@ -1,7 +1,7 @@
 import { jest } from "@jest/globals";
 import { Keypair } from "@maci-protocol/domainobjs";
 import { formatProofForVerifierContract, generateProofSnarkjs } from "@maci-protocol/sdk";
-import { TestingClass, User } from "@maci-protocol/testing";
+import { TestingClass, type User } from "@maci-protocol/testing";
 import { HttpStatus, ValidationPipe, type INestApplication } from "@nestjs/common";
 import { Test } from "@nestjs/testing";
 import request from "supertest";

--- a/apps/relayer/ts/message/__tests__/message.guard.test.ts
+++ b/apps/relayer/ts/message/__tests__/message.guard.test.ts
@@ -2,7 +2,7 @@ import { jest } from "@jest/globals";
 import { Keypair } from "@maci-protocol/domainobjs";
 import { MACI__factory as MACIFactory, Poll__factory as PollFactory } from "@maci-protocol/sdk";
 import { HttpException, type ExecutionContext } from "@nestjs/common";
-import { Reflector } from "@nestjs/core";
+import { type Reflector } from "@nestjs/core";
 import dotenv from "dotenv";
 import { ZeroAddress } from "ethers";
 

--- a/apps/relayer/ts/message/__tests__/message.repository.test.ts
+++ b/apps/relayer/ts/message/__tests__/message.repository.test.ts
@@ -1,10 +1,10 @@
 import { jest } from "@jest/globals";
 import { Keypair } from "@maci-protocol/domainobjs";
 import { ZeroAddress } from "ethers";
-import { Model } from "mongoose";
+import { type Model } from "mongoose";
 
 import { MessageRepository } from "../message.repository.js";
-import { Message } from "../message.schema.js";
+import { type Message } from "../message.schema.js";
 
 import { defaultSaveMessagesArgs } from "./utils.js";
 

--- a/apps/relayer/ts/messageBatch/__tests__/messageBatch.repository.test.ts
+++ b/apps/relayer/ts/messageBatch/__tests__/messageBatch.repository.test.ts
@@ -1,8 +1,8 @@
 import { jest } from "@jest/globals";
-import { Model } from "mongoose";
+import { type Model } from "mongoose";
 
 import { MessageBatchRepository } from "../messageBatch.repository.js";
-import { MessageBatch } from "../messageBatch.schema.js";
+import { type MessageBatch } from "../messageBatch.schema.js";
 
 import { defaultMessageBatches } from "./utils.js";
 

--- a/apps/relayer/ts/messageBatch/__tests__/messageBatch.service.test.ts
+++ b/apps/relayer/ts/messageBatch/__tests__/messageBatch.service.test.ts
@@ -1,8 +1,8 @@
 import { jest } from "@jest/globals";
 
-import { IpfsService } from "../../ipfs/ipfs.service.js";
+import { type IpfsService } from "../../ipfs/ipfs.service.js";
 import { MessageBatchDto } from "../messageBatch.dto.js";
-import { MessageBatchRepository } from "../messageBatch.repository.js";
+import { type MessageBatchRepository } from "../messageBatch.repository.js";
 import { MessageBatchService } from "../messageBatch.service.js";
 
 import { defaultIpfsHash, defaultMessageBatches } from "./utils.js";

--- a/apps/subgraph/.eslintrc.js
+++ b/apps/subgraph/.eslintrc.js
@@ -18,6 +18,7 @@ module.exports = {
     warnOnUnsupportedTypeScriptVersion: true,
   },
   rules: {
+    "@typescript-eslint/consistent-type-imports": "off",
     "@typescript-eslint/no-shadow": [
       "error",
       {

--- a/apps/subgraph/package.json
+++ b/apps/subgraph/package.json
@@ -25,7 +25,7 @@
     "remove-local": "graph remove --node http://localhost:8020/ maci-subgraph",
     "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 maci-subgraph --network localhost",
     "deploy:mainnet": "graph deploy --node https://api.studio.thegraph.com/deploy/ maci-subgraph --network mainnet",
-    "test": "graph test",
+    "test": "graph test -v 0.6.0",
     "test:coverage": "graph test && graph test -c"
   },
   "dependencies": {

--- a/packages/circuits/ts/__tests__/CeremonyParams.test.ts
+++ b/packages/circuits/ts/__tests__/CeremonyParams.test.ts
@@ -1,10 +1,10 @@
-import { MaciState, Poll, STATE_TREE_ARITY, MESSAGE_BATCH_SIZE, EMode } from "@maci-protocol/core";
+import { MaciState, type Poll, STATE_TREE_ARITY, MESSAGE_BATCH_SIZE, EMode } from "@maci-protocol/core";
 import { hash5, IncrementalQuinTree, poseidon } from "@maci-protocol/crypto";
-import { PrivateKey, Keypair, VoteCommand, Message, Ballot } from "@maci-protocol/domainobjs";
+import { PrivateKey, Keypair, VoteCommand, type Message, Ballot } from "@maci-protocol/domainobjs";
 import { expect } from "chai";
 import { type WitnessTester } from "circomkit";
 
-import { IProcessMessagesInputs, IVoteTallyInputs } from "../types";
+import { type IProcessMessagesInputs, type IVoteTallyInputs } from "../types";
 
 import { maxVoteOptions } from "./utils/constants";
 import { generateRandomIndex, circomkitInstance } from "./utils/utils";

--- a/packages/circuits/ts/__tests__/MessageProcessor.ts
+++ b/packages/circuits/ts/__tests__/MessageProcessor.ts
@@ -1,4 +1,4 @@
-import { MaciState, Poll, STATE_TREE_ARITY, EMode } from "@maci-protocol/core";
+import { MaciState, type Poll, STATE_TREE_ARITY, EMode } from "@maci-protocol/core";
 import { IncrementalQuinTree, hash2, poseidon } from "@maci-protocol/crypto";
 import { PrivateKey, Keypair, VoteCommand, Message, Ballot, PublicKey } from "@maci-protocol/domainobjs";
 import { expect } from "chai";
@@ -6,7 +6,7 @@ import { type WitnessTester } from "circomkit";
 
 import fs from "fs";
 
-import { IProcessMessagesInputs } from "../types";
+import { type IProcessMessagesInputs } from "../types";
 
 import {
   STATE_TREE_DEPTH,

--- a/packages/circuits/ts/__tests__/MessageProcessorFull.test.ts
+++ b/packages/circuits/ts/__tests__/MessageProcessorFull.test.ts
@@ -1,4 +1,4 @@
-import { MaciState, Poll, STATE_TREE_ARITY, EMode } from "@maci-protocol/core";
+import { MaciState, type Poll, STATE_TREE_ARITY, EMode } from "@maci-protocol/core";
 import { IncrementalQuinTree, hash2, poseidon } from "@maci-protocol/crypto";
 import { PrivateKey, Keypair, VoteCommand, Message, Ballot, PublicKey } from "@maci-protocol/domainobjs";
 import { expect } from "chai";
@@ -6,7 +6,7 @@ import { type WitnessTester } from "circomkit";
 
 import fs from "fs";
 
-import { IProcessMessagesInputs } from "../types";
+import { type IProcessMessagesInputs } from "../types";
 
 import {
   STATE_TREE_DEPTH,

--- a/packages/circuits/ts/__tests__/PollJoined.test.ts
+++ b/packages/circuits/ts/__tests__/PollJoined.test.ts
@@ -1,6 +1,6 @@
-import { EMode, MaciState, Poll } from "@maci-protocol/core";
+import { EMode, MaciState, type Poll } from "@maci-protocol/core";
 import { poseidon } from "@maci-protocol/crypto";
-import { Keypair, Message, VoteCommand } from "@maci-protocol/domainobjs";
+import { Keypair, type Message, VoteCommand } from "@maci-protocol/domainobjs";
 import { type WitnessTester } from "circomkit";
 
 import type { IPollJoinedInputs } from "../types";

--- a/packages/circuits/ts/__tests__/PollJoining.test.ts
+++ b/packages/circuits/ts/__tests__/PollJoining.test.ts
@@ -1,9 +1,9 @@
-import { EMode, MaciState, Poll } from "@maci-protocol/core";
+import { EMode, MaciState, type Poll } from "@maci-protocol/core";
 import { poseidon } from "@maci-protocol/crypto";
-import { Keypair, Message, VoteCommand } from "@maci-protocol/domainobjs";
+import { Keypair, type Message, VoteCommand } from "@maci-protocol/domainobjs";
 import { type WitnessTester } from "circomkit";
 
-import { IPollJoiningInputs } from "../types";
+import { type IPollJoiningInputs } from "../types";
 
 import {
   STATE_TREE_DEPTH,

--- a/packages/circuits/ts/__tests__/VoteTally.ts
+++ b/packages/circuits/ts/__tests__/VoteTally.ts
@@ -1,9 +1,9 @@
-import { EMode, MaciState, Poll } from "@maci-protocol/core";
+import { EMode, MaciState, type Poll } from "@maci-protocol/core";
 import { poseidon } from "@maci-protocol/crypto";
-import { Keypair, VoteCommand, Message } from "@maci-protocol/domainobjs";
+import { Keypair, VoteCommand, type Message } from "@maci-protocol/domainobjs";
 import { type WitnessTester } from "circomkit";
 
-import { IVoteTallyInputs } from "../types";
+import { type IVoteTallyInputs } from "../types";
 
 import { STATE_TREE_DEPTH, duration, maxVoteOptions, messageBatchSize, voiceCreditBalance } from "./utils/constants";
 import { generateRandomIndex, circomkitInstance } from "./utils/utils";

--- a/packages/cli/ts/index.ts
+++ b/packages/cli/ts/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { Command } from "@commander-js/extra-typings";
-import { PublicKey, VerifyingKey } from "@maci-protocol/domainobjs";
+import { PublicKey, type VerifyingKey } from "@maci-protocol/domainobjs";
 import {
   generateTallyCommitments,
   getPollParams,

--- a/packages/cli/ts/utils/storage.ts
+++ b/packages/cli/ts/utils/storage.ts
@@ -1,4 +1,4 @@
-import { ContractStorage, Deployment, EContracts } from "@maci-protocol/sdk";
+import { ContractStorage, Deployment, type EContracts } from "@maci-protocol/sdk";
 
 import fs from "fs";
 

--- a/packages/contracts/e2e/hardhatTasks.test.ts
+++ b/packages/contracts/e2e/hardhatTasks.test.ts
@@ -1,7 +1,7 @@
 import { poseidon } from "@maci-protocol/crypto";
-import { Keypair, Message, PrivateKey, PublicKey, VoteCommand } from "@maci-protocol/domainobjs";
+import { Keypair, type Message, PrivateKey, type PublicKey, VoteCommand } from "@maci-protocol/domainobjs";
 import { expect } from "chai";
-import { AbiCoder, Signer, TransactionReceipt } from "ethers";
+import { AbiCoder, type Signer, type TransactionReceipt } from "ethers";
 import hardhat from "hardhat";
 
 import type { EthereumProvider } from "hardhat/types";
@@ -13,7 +13,7 @@ import { EContracts } from "../tasks/helpers/types";
 import { timeTravel } from "../tests/utils";
 import { logMagenta, logRed } from "../ts/logger";
 import { sleep } from "../ts/utils";
-import { Poll, type MACI } from "../typechain-types";
+import { type Poll, type MACI } from "../typechain-types";
 
 describe("E2E hardhat tasks", function test() {
   this.timeout(900000);

--- a/packages/contracts/tasks/deploy/maci/01-policies.ts
+++ b/packages/contracts/tasks/deploy/maci/01-policies.ts
@@ -31,7 +31,7 @@ import {
   EContracts,
   EPolicyFactories,
   EPolicies,
-  IDeployParams,
+  type IDeployParams,
 } from "../../helpers/types";
 
 const deployment = Deployment.getInstance();

--- a/packages/contracts/tasks/deploy/maci/02-verifier.ts
+++ b/packages/contracts/tasks/deploy/maci/02-verifier.ts
@@ -2,7 +2,7 @@ import { info, logGreen } from "../../../ts/logger";
 import { EDeploySteps } from "../../helpers/constants";
 import { ContractStorage } from "../../helpers/ContractStorage";
 import { Deployment } from "../../helpers/Deployment";
-import { EContracts, IDeployParams } from "../../helpers/types";
+import { EContracts, type IDeployParams } from "../../helpers/types";
 
 const deployment = Deployment.getInstance();
 const storage = ContractStorage.getInstance();

--- a/packages/contracts/tasks/deploy/maci/03-poseidon.ts
+++ b/packages/contracts/tasks/deploy/maci/03-poseidon.ts
@@ -2,7 +2,7 @@ import { info, logGreen } from "../../../ts/logger";
 import { EDeploySteps } from "../../helpers/constants";
 import { ContractStorage } from "../../helpers/ContractStorage";
 import { Deployment } from "../../helpers/Deployment";
-import { EContracts, IDeployParams } from "../../helpers/types";
+import { EContracts, type IDeployParams } from "../../helpers/types";
 
 const deployment = Deployment.getInstance();
 const storage = ContractStorage.getInstance();

--- a/packages/contracts/tasks/deploy/maci/04-pollFactory.ts
+++ b/packages/contracts/tasks/deploy/maci/04-pollFactory.ts
@@ -2,7 +2,7 @@ import { info, logGreen } from "../../../ts/logger";
 import { EDeploySteps } from "../../helpers/constants";
 import { ContractStorage } from "../../helpers/ContractStorage";
 import { Deployment } from "../../helpers/Deployment";
-import { EContracts, IDeployParams } from "../../helpers/types";
+import { EContracts, type IDeployParams } from "../../helpers/types";
 
 const deployment = Deployment.getInstance();
 const storage = ContractStorage.getInstance();

--- a/packages/contracts/tasks/deploy/maci/05-messageProcessorFactory.ts
+++ b/packages/contracts/tasks/deploy/maci/05-messageProcessorFactory.ts
@@ -2,7 +2,7 @@ import { info, logGreen } from "../../../ts/logger";
 import { EDeploySteps } from "../../helpers/constants";
 import { ContractStorage } from "../../helpers/ContractStorage";
 import { Deployment } from "../../helpers/Deployment";
-import { EContracts, IDeployParams } from "../../helpers/types";
+import { EContracts, type IDeployParams } from "../../helpers/types";
 
 const deployment = Deployment.getInstance();
 const storage = ContractStorage.getInstance();

--- a/packages/contracts/tasks/deploy/maci/06-tallyFactory.ts
+++ b/packages/contracts/tasks/deploy/maci/06-tallyFactory.ts
@@ -2,7 +2,7 @@ import { info, logGreen } from "../../../ts/logger";
 import { EDeploySteps } from "../../helpers/constants";
 import { ContractStorage } from "../../helpers/ContractStorage";
 import { Deployment } from "../../helpers/Deployment";
-import { EContracts, IDeployParams } from "../../helpers/types";
+import { EContracts, type IDeployParams } from "../../helpers/types";
 
 const deployment = Deployment.getInstance();
 const storage = ContractStorage.getInstance();

--- a/packages/contracts/tasks/deploy/maci/07-maci.ts
+++ b/packages/contracts/tasks/deploy/maci/07-maci.ts
@@ -5,7 +5,7 @@ import { info, logGreen } from "../../../ts/logger";
 import { EDeploySteps, FULL_POLICY_NAMES } from "../../helpers/constants";
 import { ContractStorage } from "../../helpers/ContractStorage";
 import { Deployment } from "../../helpers/Deployment";
-import { EContracts, IDeployParams } from "../../helpers/types";
+import { EContracts, type IDeployParams } from "../../helpers/types";
 
 const deployment = Deployment.getInstance();
 const storage = ContractStorage.getInstance();

--- a/packages/contracts/tasks/deploy/maci/09-voiceCreditProxyFactory.ts
+++ b/packages/contracts/tasks/deploy/maci/09-voiceCreditProxyFactory.ts
@@ -11,7 +11,7 @@ import {
   EContracts,
   EInitialVoiceCreditProxies,
   EInitialVoiceCreditProxiesFactories,
-  IDeployParams,
+  type IDeployParams,
 } from "../../helpers/types";
 
 const deployment = Deployment.getInstance();

--- a/packages/contracts/tasks/deploy/poll/01-voiceCreditProxy.ts
+++ b/packages/contracts/tasks/deploy/poll/01-voiceCreditProxy.ts
@@ -11,7 +11,7 @@ import {
   EContracts,
   EInitialVoiceCreditProxies,
   EInitialVoiceCreditProxiesFactories,
-  IDeployParams,
+  type IDeployParams,
 } from "../../helpers/types";
 
 const DEFAULT_INITIAL_VOICE_CREDITS = 99;

--- a/packages/contracts/tasks/deploy/poll/02-policies.ts
+++ b/packages/contracts/tasks/deploy/poll/02-policies.ts
@@ -19,10 +19,10 @@ import type {
   SemaphorePolicyFactory,
   ZupassCheckerFactory,
   ZupassPolicyFactory,
+  MACI,
 } from "../../../typechain-types";
 
 import { info, logGreen } from "../../../ts/logger";
-import { MACI } from "../../../typechain-types";
 import { EDeploySteps, ESupportedChains } from "../../helpers/constants";
 import { ContractStorage } from "../../helpers/ContractStorage";
 import { Deployment } from "../../helpers/Deployment";
@@ -32,7 +32,7 @@ import {
   EContracts,
   EPolicyFactories,
   EPolicies,
-  IDeployParams,
+  type IDeployParams,
 } from "../../helpers/types";
 
 const deployment = Deployment.getInstance();

--- a/packages/contracts/tasks/deploy/poll/03-poll.ts
+++ b/packages/contracts/tasks/deploy/poll/03-poll.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import { EMode } from "@maci-protocol/core";
-import { IVerifyingKeyObjectParams, PublicKey, VerifyingKey } from "@maci-protocol/domainobjs";
+import { type IVerifyingKeyObjectParams, PublicKey, VerifyingKey } from "@maci-protocol/domainobjs";
 import { ZeroAddress } from "ethers";
 
 import type { IVerifyingKeyStruct } from "../../../ts/types";

--- a/packages/contracts/tasks/helpers/Prover.ts
+++ b/packages/contracts/tasks/helpers/Prover.ts
@@ -10,7 +10,7 @@ import type { BigNumberish } from "ethers";
 import { info, logGreen, logMagenta, success } from "../../ts/logger";
 import { asHex, formatProofForVerifierContract } from "../../ts/utils";
 
-import { IProverParams, TallyData } from "./types";
+import { type IProverParams, type TallyData } from "./types";
 
 /**
  * Prover class is designed to prove message processing and tally proofs on-chain.

--- a/packages/contracts/tasks/helpers/benchmarks.ts
+++ b/packages/contracts/tasks/helpers/benchmarks.ts
@@ -1,11 +1,11 @@
 /* eslint-disable no-console */
-import { Message, Keypair } from "@maci-protocol/domainobjs";
+import { type Message, type Keypair } from "@maci-protocol/domainobjs";
 import { TransactionReceipt } from "ethers";
 
 import { error, logGreen, logRed, success } from "../../ts/logger";
-import { MACI, Poll } from "../../typechain-types";
+import { type MACI, type Poll } from "../../typechain-types";
 
-import { Deployment } from "./Deployment";
+import { type Deployment } from "./Deployment";
 import { EContracts } from "./types";
 
 /**

--- a/packages/contracts/tasks/runner/submitOnChain.ts
+++ b/packages/contracts/tasks/runner/submitOnChain.ts
@@ -12,7 +12,7 @@ import { readProofs } from "../../ts/proofs";
 import { ContractStorage } from "../helpers/ContractStorage";
 import { Deployment } from "../helpers/Deployment";
 import { Prover } from "../helpers/Prover";
-import { EContracts, TallyData, type ISubmitOnChainParams } from "../helpers/types";
+import { EContracts, type TallyData, type ISubmitOnChainParams } from "../helpers/types";
 
 /**
  * Prove hardhat task for submitting proofs on-chain as well as uploading tally results

--- a/packages/contracts/tests/ERC20VotesInitialVoiceCreditsProxy.test.ts
+++ b/packages/contracts/tests/ERC20VotesInitialVoiceCreditsProxy.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 
-import { ERC20VotesInitialVoiceCreditProxy, getDefaultSigner, MockERC20Votes } from "../ts";
+import { type ERC20VotesInitialVoiceCreditProxy, getDefaultSigner, type MockERC20Votes } from "../ts";
 import {
   deployERC20VotesInitialVoiceCreditProxy,
   deployERC20VotesInitialVoiceCreditProxyFactory,

--- a/packages/contracts/tests/Hasher.test.ts
+++ b/packages/contracts/tests/Hasher.test.ts
@@ -1,11 +1,11 @@
 import { sha256Hash, hashLeftRight, hash3, hash4, hash5, generateRandomSalt } from "@maci-protocol/crypto";
 import { expect } from "chai";
-import { BigNumberish } from "ethers";
+import { type BigNumberish } from "ethers";
 
 import { linkPoseidonLibraries } from "../tasks/helpers/abi";
 import { deployPoseidonContracts, createContractFactory } from "../ts/deploy";
 import { getDefaultSigner } from "../ts/utils";
-import { Hasher, Hasher__factory as HasherFactory } from "../typechain-types";
+import { type Hasher, Hasher__factory as HasherFactory } from "../typechain-types";
 
 describe("Hasher", () => {
   let hasherContract: Hasher;

--- a/packages/contracts/tests/MACI.test.ts
+++ b/packages/contracts/tests/MACI.test.ts
@@ -3,15 +3,15 @@ import { EMode, MaciState } from "@maci-protocol/core";
 import { NOTHING_UP_MY_SLEEVE } from "@maci-protocol/crypto";
 import { Keypair, PublicKey, Message } from "@maci-protocol/domainobjs";
 import { expect } from "chai";
-import { AbiCoder, BigNumberish, Signer, ZeroAddress } from "ethers";
+import { AbiCoder, type BigNumberish, type Signer, ZeroAddress } from "ethers";
 
 import { getDefaultSigner, getSigners, getBlockTimestamp } from "../ts/utils";
 import {
-  MACI,
-  Verifier,
-  VerifyingKeysRegistry,
-  IBasePolicy,
-  ConstantInitialVoiceCreditProxy,
+  type MACI,
+  type Verifier,
+  type VerifyingKeysRegistry,
+  type IBasePolicy,
+  type ConstantInitialVoiceCreditProxy,
 } from "../typechain-types";
 
 import {

--- a/packages/contracts/tests/MessageProcessor.test.ts
+++ b/packages/contracts/tests/MessageProcessor.test.ts
@@ -1,23 +1,23 @@
 /* eslint-disable no-underscore-dangle */
-import { EMode, MaciState, Poll, IProcessMessagesCircuitInputs } from "@maci-protocol/core";
+import { EMode, MaciState, type Poll, type IProcessMessagesCircuitInputs } from "@maci-protocol/core";
 import { NOTHING_UP_MY_SLEEVE } from "@maci-protocol/crypto";
 import { Keypair, Message, PublicKey } from "@maci-protocol/domainobjs";
 import { expect } from "chai";
-import { Signer, ZeroAddress } from "ethers";
-import { EthereumProvider } from "hardhat/types";
+import { type Signer, ZeroAddress } from "ethers";
+import { type EthereumProvider } from "hardhat/types";
 
-import { IVerifyingKeyStruct } from "../ts/types";
+import { type IVerifyingKeyStruct } from "../ts/types";
 import { getDefaultSigner, getBlockTimestamp } from "../ts/utils";
 import {
-  MACI,
-  MessageProcessor,
-  Poll as PollContract,
+  type MACI,
+  type MessageProcessor,
+  type Poll as PollContract,
   MessageProcessor__factory as MessageProcessorFactory,
   Poll__factory as PollFactory,
-  Verifier,
-  VerifyingKeysRegistry,
-  IBasePolicy,
-  ConstantInitialVoiceCreditProxy,
+  type Verifier,
+  type VerifyingKeysRegistry,
+  type IBasePolicy,
+  type ConstantInitialVoiceCreditProxy,
 } from "../typechain-types";
 
 import {

--- a/packages/contracts/tests/Poll.test.ts
+++ b/packages/contracts/tests/Poll.test.ts
@@ -4,20 +4,20 @@ import { EMode, MaciState } from "@maci-protocol/core";
 import { NOTHING_UP_MY_SLEEVE } from "@maci-protocol/crypto";
 import { Keypair, Message, VoteCommand, PublicKey, StateLeaf } from "@maci-protocol/domainobjs";
 import { expect } from "chai";
-import { AbiCoder, decodeBase58, encodeBase58, getBytes, hexlify, Signer, ZeroAddress } from "ethers";
-import { EthereumProvider } from "hardhat/types";
+import { AbiCoder, decodeBase58, encodeBase58, getBytes, hexlify, type Signer, ZeroAddress } from "ethers";
+import { type EthereumProvider } from "hardhat/types";
 
 import { deployFreeForAllSignUpPolicy } from "../ts/deploy";
-import { IVerifyingKeyStruct } from "../ts/types";
+import { type IVerifyingKeyStruct } from "../ts/types";
 import { getBlockTimestamp, getDefaultSigner, getSigners } from "../ts/utils";
 import {
   Poll__factory as PollFactory,
-  MACI,
-  Poll as PollContract,
-  Verifier,
-  VerifyingKeysRegistry,
-  IBasePolicy,
-  ConstantInitialVoiceCreditProxy,
+  type MACI,
+  type Poll as PollContract,
+  type Verifier,
+  type VerifyingKeysRegistry,
+  type IBasePolicy,
+  type ConstantInitialVoiceCreditProxy,
 } from "../typechain-types";
 
 import {

--- a/packages/contracts/tests/PollFactory.test.ts
+++ b/packages/contracts/tests/PollFactory.test.ts
@@ -1,16 +1,16 @@
 import { Keypair } from "@maci-protocol/domainobjs";
 import { expect } from "chai";
-import { BaseContract, Signer, ZeroAddress } from "ethers";
+import { type BaseContract, type Signer, ZeroAddress } from "ethers";
 
 import { deployPollFactory, generateEmptyBallotRoots, getDefaultSigner } from "../ts";
-import { MACI, PollFactory, Verifier, VerifyingKeysRegistry } from "../typechain-types";
+import { type MACI, type PollFactory, type Verifier, type VerifyingKeysRegistry } from "../typechain-types";
 
 import {
   messageBatchSize,
   initialVoiceCreditBalance,
   STATE_TREE_DEPTH,
   treeDepths,
-  ExtContractsStruct,
+  type ExtContractsStruct,
   maxVoteOptions,
 } from "./constants";
 import { deployTestContracts } from "./utils";

--- a/packages/contracts/tests/Tally.test.ts
+++ b/packages/contracts/tests/Tally.test.ts
@@ -1,5 +1,11 @@
 /* eslint-disable no-underscore-dangle */
-import { EMode, MaciState, Poll, IProcessMessagesCircuitInputs, IVoteTallyCircuitInputs } from "@maci-protocol/core";
+import {
+  EMode,
+  MaciState,
+  type Poll,
+  type IProcessMessagesCircuitInputs,
+  type IVoteTallyCircuitInputs,
+} from "@maci-protocol/core";
 import {
   generateTreeCommitment,
   generateTreeProof,
@@ -9,24 +15,24 @@ import {
 } from "@maci-protocol/crypto";
 import { Keypair, Message, PublicKey } from "@maci-protocol/domainobjs";
 import { expect } from "chai";
-import { AbiCoder, BigNumberish, Signer, ZeroAddress } from "ethers";
-import { EthereumProvider } from "hardhat/types";
+import { AbiCoder, type BigNumberish, type Signer, ZeroAddress } from "ethers";
+import { type EthereumProvider } from "hardhat/types";
 
 import { deployFreeForAllSignUpPolicy } from "../ts/deploy";
-import { IVerifyingKeyStruct } from "../ts/types";
+import { type IVerifyingKeyStruct } from "../ts/types";
 import { asHex, getDefaultSigner, getBlockTimestamp } from "../ts/utils";
 import {
-  Tally,
-  MACI,
-  Poll as PollContract,
-  MessageProcessor,
-  Verifier,
-  VerifyingKeysRegistry,
+  type Tally,
+  type MACI,
+  type Poll as PollContract,
+  type MessageProcessor,
+  type Verifier,
+  type VerifyingKeysRegistry,
   MessageProcessor__factory as MessageProcessorFactory,
   Poll__factory as PollFactory,
   Tally__factory as TallyFactory,
-  IBasePolicy,
-  ConstantInitialVoiceCreditProxy,
+  type IBasePolicy,
+  type ConstantInitialVoiceCreditProxy,
 } from "../typechain-types";
 
 import {

--- a/packages/contracts/tests/TallyNonQv.test.ts
+++ b/packages/contracts/tests/TallyNonQv.test.ts
@@ -1,25 +1,31 @@
 /* eslint-disable no-underscore-dangle */
-import { EMode, MaciState, Poll, IProcessMessagesCircuitInputs, IVoteTallyCircuitInputs } from "@maci-protocol/core";
+import {
+  EMode,
+  MaciState,
+  type Poll,
+  type IProcessMessagesCircuitInputs,
+  type IVoteTallyCircuitInputs,
+} from "@maci-protocol/core";
 import { NOTHING_UP_MY_SLEEVE } from "@maci-protocol/crypto";
 import { Keypair, Message, PublicKey } from "@maci-protocol/domainobjs";
 import { expect } from "chai";
-import { Signer, ZeroAddress } from "ethers";
-import { EthereumProvider } from "hardhat/types";
+import { type Signer, ZeroAddress } from "ethers";
+import { type EthereumProvider } from "hardhat/types";
 
-import { IVerifyingKeyStruct } from "../ts/types";
+import { type IVerifyingKeyStruct } from "../ts/types";
 import { getDefaultSigner, getBlockTimestamp } from "../ts/utils";
 import {
-  Tally,
-  MACI,
-  Poll as PollContract,
-  MessageProcessor,
-  Verifier,
-  VerifyingKeysRegistry,
+  type Tally,
+  type MACI,
+  type Poll as PollContract,
+  type MessageProcessor,
+  type Verifier,
+  type VerifyingKeysRegistry,
   MessageProcessor__factory as MessageProcessorFactory,
   Poll__factory as PollFactory,
   Tally__factory as TallyFactory,
-  IBasePolicy,
-  ConstantInitialVoiceCreditProxy,
+  type IBasePolicy,
+  type ConstantInitialVoiceCreditProxy,
 } from "../typechain-types";
 
 import {

--- a/packages/contracts/tests/Utilities.test.ts
+++ b/packages/contracts/tests/Utilities.test.ts
@@ -1,11 +1,11 @@
 import { StateLeaf, Keypair, Message, PublicKey } from "@maci-protocol/domainobjs";
 import { expect } from "chai";
-import { BigNumberish, ZeroAddress } from "ethers";
+import { type BigNumberish, ZeroAddress } from "ethers";
 
 import { linkPoseidonLibraries } from "../tasks/helpers/abi";
 import { deployPoseidonContracts, createContractFactory } from "../ts/deploy";
 import { getDefaultSigner } from "../ts/utils";
-import { Utilities, Utilities__factory as UtilitiesFactory } from "../typechain-types";
+import { type Utilities, Utilities__factory as UtilitiesFactory } from "../typechain-types";
 
 describe("Utilities", () => {
   let utilitiesContract: Utilities;

--- a/packages/contracts/tests/Verifier.test.ts
+++ b/packages/contracts/tests/Verifier.test.ts
@@ -7,7 +7,7 @@ import type { BigNumberish } from "ethers";
 
 import { deployVerifier } from "../ts/deploy";
 import { getDefaultSigner } from "../ts/utils";
-import { Verifier } from "../typechain-types";
+import { type Verifier } from "../typechain-types";
 
 describe("DomainObjs", () => {
   const verifyingKey = new VerifyingKey(

--- a/packages/contracts/tests/VerifyingKeysRegistry.test.ts
+++ b/packages/contracts/tests/VerifyingKeysRegistry.test.ts
@@ -1,8 +1,13 @@
 import { EMode } from "@maci-protocol/core";
 import { expect } from "chai";
-import { Signer } from "ethers";
+import { type Signer } from "ethers";
 
-import { IVerifyingKeyStruct, VerifyingKeysRegistry, deployVerifyingKeysRegistry, getDefaultSigner } from "../ts";
+import {
+  type IVerifyingKeyStruct,
+  type VerifyingKeysRegistry,
+  deployVerifyingKeysRegistry,
+  getDefaultSigner,
+} from "../ts";
 
 import {
   messageBatchSize,

--- a/packages/contracts/tests/constants.ts
+++ b/packages/contracts/tests/constants.ts
@@ -1,7 +1,7 @@
-import { ITreeDepths, STATE_TREE_ARITY } from "@maci-protocol/core";
+import { type ITreeDepths, STATE_TREE_ARITY } from "@maci-protocol/core";
 import { G1Point, G2Point } from "@maci-protocol/crypto";
 import { VerifyingKey } from "@maci-protocol/domainobjs";
-import { AddressLike } from "ethers";
+import { type AddressLike } from "ethers";
 
 export interface ExtContractsStruct {
   maci: AddressLike;

--- a/packages/contracts/tests/policies/AnonAadhaarPolicy.test.ts
+++ b/packages/contracts/tests/policies/AnonAadhaarPolicy.test.ts
@@ -1,6 +1,6 @@
 import { Keypair } from "@maci-protocol/domainobjs";
 import { expect } from "chai";
-import { AbiCoder, Signer, ZeroAddress } from "ethers";
+import { AbiCoder, type Signer, ZeroAddress } from "ethers";
 
 import type { MACI, AnonAadhaarPolicy, MockAnonAadhaar, AnonAadhaarChecker } from "../../typechain-types";
 

--- a/packages/contracts/tests/policies/EASPolicy.test.ts
+++ b/packages/contracts/tests/policies/EASPolicy.test.ts
@@ -1,6 +1,6 @@
 import { Keypair } from "@maci-protocol/domainobjs";
 import { expect } from "chai";
-import { Signer, ZeroAddress, toBeArray } from "ethers";
+import { type Signer, ZeroAddress, toBeArray } from "ethers";
 
 import type { MACI, EASChecker, EASPolicy } from "../../typechain-types";
 

--- a/packages/contracts/tests/policies/ERC20.test.ts
+++ b/packages/contracts/tests/policies/ERC20.test.ts
@@ -1,10 +1,10 @@
 import { Keypair } from "@maci-protocol/domainobjs";
 import { expect } from "chai";
-import { AbiCoder, Signer, ZeroAddress } from "ethers";
+import { AbiCoder, type Signer, ZeroAddress } from "ethers";
 
 import { getSigners } from "../../ts";
 import { deployERC20Policy, deployMockERC20Votes } from "../../ts/deploy";
-import { ERC20Policy, MockERC20, ERC20Checker, MACI } from "../../typechain-types";
+import { type ERC20Policy, type MockERC20, type ERC20Checker, type MACI } from "../../typechain-types";
 import { STATE_TREE_DEPTH, initialVoiceCreditBalance } from "../constants";
 import { deployTestContracts } from "../utils";
 

--- a/packages/contracts/tests/policies/ERC20Votes.test.ts
+++ b/packages/contracts/tests/policies/ERC20Votes.test.ts
@@ -1,10 +1,10 @@
 import { Keypair } from "@maci-protocol/domainobjs";
 import { expect } from "chai";
-import { AbiCoder, Signer, ZeroAddress } from "ethers";
+import { AbiCoder, type Signer, ZeroAddress } from "ethers";
 
 import { getSigners } from "../../ts";
 import { deployERC20VotesPolicy, deployMockERC20Votes } from "../../ts/deploy";
-import { ERC20VotesPolicy, MockERC20Votes, ERC20VotesChecker, MACI } from "../../typechain-types";
+import { type ERC20VotesPolicy, type MockERC20Votes, type ERC20VotesChecker, type MACI } from "../../typechain-types";
 import { STATE_TREE_DEPTH, initialVoiceCreditBalance } from "../constants";
 import { deployTestContracts } from "../utils";
 

--- a/packages/contracts/tests/policies/GitcoinPassportPolicy.test.ts
+++ b/packages/contracts/tests/policies/GitcoinPassportPolicy.test.ts
@@ -1,6 +1,6 @@
 import { Keypair } from "@maci-protocol/domainobjs";
 import { expect } from "chai";
-import { AbiCoder, Signer, ZeroAddress } from "ethers";
+import { AbiCoder, type Signer, ZeroAddress } from "ethers";
 
 import type {
   MACI,

--- a/packages/contracts/tests/policies/HatsPolicy.test.ts
+++ b/packages/contracts/tests/policies/HatsPolicy.test.ts
@@ -1,6 +1,6 @@
 import { Keypair } from "@maci-protocol/domainobjs";
 import { expect } from "chai";
-import { AbiCoder, Signer, ZeroAddress } from "ethers";
+import { AbiCoder, type Signer, ZeroAddress } from "ethers";
 
 import type { MACI, HatsChecker, HatsPolicy, MockHatsProtocol } from "../../typechain-types";
 

--- a/packages/contracts/tests/policies/MerkleProofPolicy.test.ts
+++ b/packages/contracts/tests/policies/MerkleProofPolicy.test.ts
@@ -1,7 +1,7 @@
 import { Keypair } from "@maci-protocol/domainobjs";
-import { StandardMerkleTree } from "@openzeppelin/merkle-tree";
+import { type StandardMerkleTree } from "@openzeppelin/merkle-tree";
 import { expect } from "chai";
-import { AbiCoder, Signer, ZeroAddress, encodeBytes32String } from "ethers";
+import { AbiCoder, type Signer, ZeroAddress, encodeBytes32String } from "ethers";
 
 import type { MACI, MerkleProofPolicy, MerkleProofChecker } from "../../typechain-types";
 

--- a/packages/contracts/tests/policies/SemaphorePolicy.test.ts
+++ b/packages/contracts/tests/policies/SemaphorePolicy.test.ts
@@ -1,6 +1,6 @@
 import { Keypair } from "@maci-protocol/domainobjs";
 import { expect } from "chai";
-import { AbiCoder, Signer, ZeroAddress } from "ethers";
+import { AbiCoder, type Signer, ZeroAddress } from "ethers";
 
 import type { MACI, MockSemaphore, SemaphorePolicy, SemaphoreChecker } from "../../typechain-types";
 

--- a/packages/contracts/tests/policies/SignUpPolicy.test.ts
+++ b/packages/contracts/tests/policies/SignUpPolicy.test.ts
@@ -1,6 +1,6 @@
 import { Keypair } from "@maci-protocol/domainobjs";
 import { expect } from "chai";
-import { AbiCoder, ZeroAddress, Signer } from "ethers";
+import { AbiCoder, ZeroAddress, type Signer } from "ethers";
 
 import type {
   MACI,

--- a/packages/contracts/tests/policies/Zupass.test.ts
+++ b/packages/contracts/tests/policies/Zupass.test.ts
@@ -1,6 +1,6 @@
 import { Keypair } from "@maci-protocol/domainobjs";
 import { expect } from "chai";
-import { Signer, ZeroAddress } from "ethers";
+import { type Signer, ZeroAddress } from "ethers";
 
 import type { MACI, ZupassChecker, ZupassPolicy } from "../../typechain-types";
 

--- a/packages/contracts/tests/utils.ts
+++ b/packages/contracts/tests/utils.ts
@@ -1,5 +1,5 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import { IVerifyingKeyContractParams, VerifyingKey } from "@maci-protocol/domainobjs";
+import { type IVerifyingKeyContractParams, type VerifyingKey } from "@maci-protocol/domainobjs";
 import { expect } from "chai";
 
 import type { IDeployedTestContracts, IDeployedTestContractsArgs } from "../ts/types";

--- a/packages/contracts/ts/utils.ts
+++ b/packages/contracts/ts/utils.ts
@@ -1,5 +1,5 @@
 import { StandardMerkleTree } from "@openzeppelin/merkle-tree";
-import { Interface, TransactionReceipt, type BigNumberish, type FeeData, type Network, type Signer } from "ethers";
+import { Interface, type TransactionReceipt, type BigNumberish, type FeeData, type Network, type Signer } from "ethers";
 
 import fs from "fs";
 import os from "os";

--- a/packages/core/ts/MaciState.ts
+++ b/packages/core/ts/MaciState.ts
@@ -1,10 +1,10 @@
-import { IncrementalQuinTree } from "@maci-protocol/crypto";
+import { type IncrementalQuinTree } from "@maci-protocol/crypto";
 import { PublicKey, type Keypair, padKey } from "@maci-protocol/domainobjs";
 
 import type { IJsonMaciState, IJsonPoll, IMaciState, ITreeDepths } from "./utils/types";
 
 import { Poll } from "./Poll";
-import { EMode, STATE_TREE_ARITY } from "./utils/constants";
+import { type EMode, STATE_TREE_ARITY } from "./utils/constants";
 
 /**
  * A representation of the MACI contract.

--- a/packages/core/ts/Poll.ts
+++ b/packages/core/ts/Poll.ts
@@ -26,7 +26,7 @@ import {
   padKey,
   type IMessageContractParams,
 } from "@maci-protocol/domainobjs";
-import { LeanIMT, LeanIMTHashFunction } from "@zk-kit/lean-imt";
+import { LeanIMT, type LeanIMTHashFunction } from "@zk-kit/lean-imt";
 import omit from "lodash/omit";
 
 import assert from "assert";

--- a/packages/core/ts/__tests__/MaciState.test.ts
+++ b/packages/core/ts/__tests__/MaciState.test.ts
@@ -1,11 +1,11 @@
-import { VoteCommand, Message, Keypair } from "@maci-protocol/domainobjs";
+import { VoteCommand, type Message, Keypair } from "@maci-protocol/domainobjs";
 import { expect } from "chai";
 
 import fs from "fs";
 
 import { MaciState } from "../MaciState";
 import { EMode, STATE_TREE_DEPTH } from "../utils/constants";
-import { IJsonMaciState } from "../utils/types";
+import { type IJsonMaciState } from "../utils/types";
 
 import { coordinatorKeypair, duration, maxVoteOptions, messageBatchSize, treeDepths } from "./utils/constants";
 

--- a/packages/core/ts/__tests__/Poll.test.ts
+++ b/packages/core/ts/__tests__/Poll.test.ts
@@ -1,5 +1,5 @@
 import { poseidon } from "@maci-protocol/crypto";
-import { VoteCommand, Keypair, StateLeaf, PrivateKey, Ballot } from "@maci-protocol/domainobjs";
+import { VoteCommand, Keypair, type StateLeaf, PrivateKey, type Ballot } from "@maci-protocol/domainobjs";
 import { expect } from "chai";
 
 import { MaciState } from "../MaciState";

--- a/packages/core/ts/__tests__/e2e.test.ts
+++ b/packages/core/ts/__tests__/e2e.test.ts
@@ -1,10 +1,10 @@
 import { hash5, IncrementalQuinTree, poseidon, PAD_KEY_HASH, hashLeanIMT } from "@maci-protocol/crypto";
 import { VoteCommand, Keypair, blankStateLeafHash } from "@maci-protocol/domainobjs";
-import { LeanIMT, LeanIMTHashFunction } from "@zk-kit/lean-imt";
+import { LeanIMT, type LeanIMTHashFunction } from "@zk-kit/lean-imt";
 import { expect } from "chai";
 
 import { MaciState } from "../MaciState";
-import { Poll } from "../Poll";
+import { type Poll } from "../Poll";
 import { STATE_TREE_DEPTH, STATE_TREE_ARITY, EMode } from "../utils/constants";
 
 import {

--- a/packages/core/ts/__tests__/utils/utils.ts
+++ b/packages/core/ts/__tests__/utils/utils.ts
@@ -1,8 +1,8 @@
-import { Signature } from "@maci-protocol/crypto";
-import { VoteCommand, Message, Keypair, PublicKey } from "@maci-protocol/domainobjs";
+import { type Signature } from "@maci-protocol/crypto";
+import { VoteCommand, type Message, Keypair, type PublicKey } from "@maci-protocol/domainobjs";
 
 import { MaciState } from "../../MaciState";
-import { Poll } from "../../Poll";
+import { type Poll } from "../../Poll";
 import { EMode, STATE_TREE_DEPTH } from "../../utils/constants";
 
 import { duration, maxVoteOptions, messageBatchSize, treeDepths } from "./constants";

--- a/packages/crypto/ts/keys.ts
+++ b/packages/crypto/ts/keys.ts
@@ -9,7 +9,7 @@ import {
 import { randomBytes } from "crypto";
 
 import { generateRandomBabyJubValue } from "./babyjub";
-import { EcdhSharedKey, Keypair, Point, PrivateKey, PublicKey } from "./types";
+import { type EcdhSharedKey, type Keypair, type Point, type PrivateKey, type PublicKey } from "./types";
 
 /**
  * Generate a private key

--- a/packages/domainobjs/ts/__tests__/verifyingKey.test.ts
+++ b/packages/domainobjs/ts/__tests__/verifyingKey.test.ts
@@ -1,10 +1,10 @@
-import { G1Point } from "@maci-protocol/crypto";
+import { type G1Point } from "@maci-protocol/crypto";
 import { expect } from "chai";
 
 import fs from "fs";
 import path from "path";
 
-import { IVerifyingKeyObjectParams, VerifyingKey } from "..";
+import { type IVerifyingKeyObjectParams, VerifyingKey } from "..";
 
 describe("verifyingKey", () => {
   describe("fromJSON", () => {

--- a/packages/domainobjs/ts/keyPair.ts
+++ b/packages/domainobjs/ts/keyPair.ts
@@ -1,4 +1,4 @@
-import { EcdhSharedKey, generateEcdhSharedKey, generateKeypair, generatePublicKey } from "@maci-protocol/crypto";
+import { type EcdhSharedKey, generateEcdhSharedKey, generateKeypair, generatePublicKey } from "@maci-protocol/crypto";
 
 import assert from "assert";
 

--- a/packages/sdk/ts/deploy/types.ts
+++ b/packages/sdk/ts/deploy/types.ts
@@ -1,6 +1,6 @@
-import { TAbi } from "@maci-protocol/contracts";
-import { EMode } from "@maci-protocol/core";
-import { PublicKey } from "@maci-protocol/domainobjs";
+import { type TAbi } from "@maci-protocol/contracts";
+import { type EMode } from "@maci-protocol/core";
+import { type PublicKey } from "@maci-protocol/domainobjs";
 
 import type { Signer } from "ethers";
 

--- a/packages/sdk/ts/maciKeys/types.ts
+++ b/packages/sdk/ts/maciKeys/types.ts
@@ -1,4 +1,4 @@
-import { IG1ContractParams } from "@maci-protocol/domainobjs";
+import { type IG1ContractParams } from "@maci-protocol/domainobjs";
 
 /**
  * Interface for the arguments for generate keypair command

--- a/packages/sdk/ts/proof/__tests__/download.test.ts
+++ b/packages/sdk/ts/proof/__tests__/download.test.ts
@@ -1,6 +1,6 @@
 import { generateProofSnarkjs } from "@maci-protocol/contracts";
 
-import { TCircuitInputs } from "../../utils/types";
+import { type TCircuitInputs } from "../../utils/types";
 import { downloadPollJoiningArtifactsBrowser } from "../download";
 
 /**

--- a/packages/sdk/ts/trees/stateTree.ts
+++ b/packages/sdk/ts/trees/stateTree.ts
@@ -2,7 +2,7 @@
 import { MACI__factory as MACIFactory } from "@maci-protocol/contracts/typechain-types";
 import { hashLeanIMT, hashLeftRight, PAD_KEY_HASH } from "@maci-protocol/crypto";
 import { PublicKey } from "@maci-protocol/domainobjs";
-import { LeanIMT, LeanIMTHashFunction } from "@zk-kit/lean-imt";
+import { LeanIMT, type LeanIMTHashFunction } from "@zk-kit/lean-imt";
 
 import type { IGenerateSignUpTreeArgs, IGenerateSignUpTree, IGenerateSignUpTreeWithEndKeyArgs } from "./types";
 

--- a/packages/sdk/ts/user/signup.ts
+++ b/packages/sdk/ts/user/signup.ts
@@ -1,6 +1,6 @@
 import { MACI__factory as MACIFactory } from "@maci-protocol/contracts/typechain-types";
 import { PublicKey } from "@maci-protocol/domainobjs";
-import { ContractTransactionReceipt, isBytesLike } from "ethers";
+import { type ContractTransactionReceipt, isBytesLike } from "ethers";
 
 import type { IIsRegisteredUser, ISignupArgs, ISignupData, IRegisteredUserArgs, IHasUserSignedUpArgs } from "./types";
 

--- a/packages/testing/ts/__tests__/unit/setVerifyingKeys.test.ts
+++ b/packages/testing/ts/__tests__/unit/setVerifyingKeys.test.ts
@@ -1,6 +1,6 @@
 import { deployVerifyingKeysRegistryContract, EMode, getDefaultSigner, setVerifyingKeys } from "@maci-protocol/sdk";
 import { expect } from "chai";
-import { Signer } from "ethers";
+import { type Signer } from "ethers";
 
 import { verifyingKeysArgs } from "../../constants";
 

--- a/packages/testing/ts/__tests__/unit/signup.test.ts
+++ b/packages/testing/ts/__tests__/unit/signup.test.ts
@@ -10,7 +10,7 @@ import {
   deployVerifyingKeysRegistryContract,
 } from "@maci-protocol/sdk";
 import { expect } from "chai";
-import { Signer } from "ethers";
+import { type Signer } from "ethers";
 
 import { deployArgs, verifyingKeysArgs, DEFAULT_SG_DATA } from "../../constants";
 

--- a/packages/testing/ts/types.ts
+++ b/packages/testing/ts/types.ts
@@ -1,14 +1,14 @@
-import { generateMaciStateFromContract } from "@maci-protocol/sdk";
+import {
+  type generateMaciStateFromContract,
+  type MACI,
+  type Verifier,
+  type VerifyingKeysRegistry,
+  type FreeForAllPolicy,
+  type ConstantInitialVoiceCreditProxy,
+  type IIpfsMessage,
+} from "@maci-protocol/sdk";
 
 import type { User } from "./user";
-import type {
-  MACI,
-  Verifier,
-  VerifyingKeysRegistry,
-  FreeForAllPolicy,
-  ConstantInitialVoiceCreditProxy,
-  IIpfsMessage,
-} from "@maci-protocol/sdk";
 import type { Signer } from "ethers";
 
 /**


### PR DESCRIPTION
# Description

- [x] Fix lint warning and convert rule to error
- [x] Specify explicit version for subgraph tests 

## Additional Notes

Changes are made with `pnpm run lint:ts:fix`

## Related issue(s)

Related to #2665 

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I ran and verified that all tests pass according to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
