### PR TITLE
chore: increase memory for stress tests

### DIFF
--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -24,7 +24,7 @@
     "test:e2e-full": "NODE_ENV=test ts-mocha --exit ./ts/__tests__/e2e.full.test.ts",
     "test:keyChange": "NODE_ENV=test ts-mocha --exit ./ts/__tests__/keyChange.test.ts",
     "test:unit": "NODE_ENV=test ts-mocha --exit ./ts/__tests__/unit/*.test.ts",
-    "test:stress": "NODE_ENV=test ts-mocha --exit ./ts/__tests__/stress/*.test.ts"
+    "test:stress": "NODE_OPTIONS=--max-old-space-size=4096 NODE_ENV=test ts-mocha --exit ./ts/__tests__/stress/*.test.ts"
   },
   "devDependencies": {
     "@types/chai-as-promised": "^8.0.2",


### PR DESCRIPTION
# Description

Increase memory for stress tests ci job

## Additional Notes

Stress tests are failing because there are too many users and messages and it causes memory issues.

## Related issue(s)

N/A

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I ran and verified that all tests pass according to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
