### PR TITLE
chore: use rapidsnark for macos

### DIFF
--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -1,0 +1,92 @@
+name: Nightly Unit Tests Macos
+
+on:
+  pull_request:
+
+env:
+  NODE_OPTIONS: "--max-old-space-size=4096"
+
+jobs:
+  macos-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        command: ["test:stress"]
+
+    runs-on: macos-15
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "pnpm"
+
+      - name: Download circom Binary v2.1.6
+        run: |
+          wget -qO ${{ github.workspace }}/circom https://github.com/iden3/circom/releases/download/v2.1.6/circom-macos-amd64
+          chmod +x ${{ github.workspace }}/circom
+          echo "${{ github.workspace }}" >> $GITHUB_PATH
+
+      - name: Install dependencies
+        run: |
+          brew install gmp libsodium nasm
+
+      - name: Download rapidsnark (v0.0.7)
+        run: |
+          mkdir -p ~/rapidsnark/build
+          curl -L -o ~/rapidsnark/rapidsnark.zip https://github.com/iden3/rapidsnark/releases/download/v0.0.7/rapidsnark-macOS-arm64-v0.0.7.zip
+          unzip -q ~/rapidsnark/rapidsnark.zip -d ~/rapidsnark/
+          cp ~/rapidsnark/rapidsnark-macOS-arm64-v0.0.7/bin/prover ~/rapidsnark/build/prover
+          chmod +x ~/rapidsnark/build/prover
+
+      - name: Verify Rapidsnark Version
+        run: |
+          ~/rapidsnark/build/prover --help
+
+      - name: Install
+        run: |
+          pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Build
+        run: |
+          pnpm run build
+
+      - name: Run hardhat fork
+        run: |
+          cd packages/contracts
+          cp ./deploy-config-example.json ./deploy-config.json
+          pnpm run hardhat &
+
+      - name: Calculate circuits hash
+        id: hash_circuits
+        run: |
+          CIRCUIT_HASH=$(find packages/circuits -type f -name '*.circom' -exec sha1sum {} \; | sort | sha1sum | cut -d ' ' -f1)
+          echo "CIRCUIT_HASH=$CIRCUIT_HASH" >> $GITHUB_ENV
+          echo "CIRCUIT_HASH=$CIRCUIT_HASH" >> $GITHUB_OUTPUT
+
+      - name: Cache zkeys
+        id: cache_zkeys
+        uses: actions/cache@v4
+        with:
+          path: zkeys
+          key: zkeys-${{ steps.hash_circuits.outputs.CIRCUIT_HASH }}
+          restore-keys: |
+            zkeys-
+
+      - name: Download zkeys
+        run: |
+          pnpm download-zkeys:test
+
+      - name: ${{ matrix.command }}
+        run: pnpm run ${{ matrix.command }}
+
+      - name: Stop Hardhat
+        if: always()
+        run: kill $(lsof -t -i:8545)

--- a/apps/coordinator/tests/e2e.deploy.test.ts
+++ b/apps/coordinator/tests/e2e.deploy.test.ts
@@ -1,5 +1,5 @@
 import { Keypair } from "@maci-protocol/domainobjs";
-import { isArm, joinPoll, signup, sleepUntil, ESupportedChains, ContractStorage } from "@maci-protocol/sdk";
+import { joinPoll, signup, sleepUntil, ESupportedChains, ContractStorage } from "@maci-protocol/sdk";
 import { ValidationPipe, type INestApplication } from "@nestjs/common";
 import { Test } from "@nestjs/testing";
 import dotenv from "dotenv";
@@ -52,7 +52,7 @@ const VOTE_OPTIONS: Record<string, number> = {
   "1": 0,
 };
 
-const useWasm = isArm();
+const useWasm = false;
 
 describe("E2E Deployment Tests", () => {
   let signer: Signer;

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -17,14 +17,14 @@
     "build": "tsc",
     "types": "tsc -p tsconfig.json --noEmit",
     "test": "ts-mocha --exit ./ts/__tests__/**/*.test.ts",
-    "test:integration": "NODE_OPTIONS=--max-old-space-size=4096 ts-mocha --exit  ./ts/__tests__/integration.test.ts",
+    "test:integration": "ts-mocha --exit  ./ts/__tests__/integration.test.ts",
     "test:e2e": "NODE_ENV=test ts-mocha --exit ./ts/__tests__/e2e*.test.ts",
     "test:e2e-qv": "NODE_ENV=test ts-mocha --exit ./ts/__tests__/e2e.test.ts",
     "test:e2e-non-qv": "NODE_ENV=test ts-mocha --exit ./ts/__tests__/e2e.nonQv.test.ts",
     "test:e2e-full": "NODE_ENV=test ts-mocha --exit ./ts/__tests__/e2e.full.test.ts",
     "test:keyChange": "NODE_ENV=test ts-mocha --exit ./ts/__tests__/keyChange.test.ts",
     "test:unit": "NODE_ENV=test ts-mocha --exit ./ts/__tests__/unit/*.test.ts",
-    "test:stress": "NODE_OPTIONS=--max-old-space-size=4096 NODE_ENV=test ts-mocha --exit ./ts/__tests__/stress/*.test.ts"
+    "test:stress": "NODE_ENV=test ts-mocha --exit ./ts/__tests__/stress/*.test.ts"
   },
   "devDependencies": {
     "@types/chai-as-promised": "^8.0.2",

--- a/packages/testing/ts/__tests__/e2e.full.test.ts
+++ b/packages/testing/ts/__tests__/e2e.full.test.ts
@@ -16,7 +16,6 @@ import {
   generateProofs,
   deployVerifyingKeysRegistryContract,
   timeTravel,
-  isArm,
   deployMaci,
   deployFreeForAllSignUpPolicy,
   deployConstantInitialVoiceCreditProxy,
@@ -71,7 +70,7 @@ import { clean, getBackupFilenames, relayTestMessages } from "../utils";
     30 signups, 30 invalid and 1 valid messages
  */
 describe("e2e tests with full credits voting", function test() {
-  const useWasm = isArm();
+  const useWasm = false;
   this.timeout(900000);
 
   let maciAddresses: IMaciContracts;

--- a/packages/testing/ts/__tests__/e2e.nonQv.test.ts
+++ b/packages/testing/ts/__tests__/e2e.nonQv.test.ts
@@ -17,7 +17,6 @@ import {
   deployVerifyingKeysRegistryContract,
   timeTravel,
   type IGenerateProofsArgs,
-  isArm,
   deployMaci,
   type IMaciContracts,
   deployFreeForAllSignUpPolicy,
@@ -69,7 +68,7 @@ import { clean, getBackupFilenames, relayTestMessages } from "../utils";
     2 signups, 2 different messages
  */
 describe("e2e tests with non quadratic voting", function test() {
-  const useWasm = isArm();
+  const useWasm = false;
   this.timeout(900000);
 
   let maciAddresses: IMaciContracts;

--- a/packages/testing/ts/__tests__/e2e.test.ts
+++ b/packages/testing/ts/__tests__/e2e.test.ts
@@ -20,7 +20,6 @@ import {
   deployVerifyingKeysRegistryContract,
   timeTravel,
   type IGenerateProofsArgs,
-  isArm,
   deployMaci,
   type IMaciContracts,
   deployFreeForAllSignUpPolicy,
@@ -78,7 +77,7 @@ import { clean, getBackupFilenames, relayTestMessages } from "../utils";
     7 signups and 1 message, another polls and 6 messages
  */
 describe("e2e tests", function test() {
-  const useWasm = isArm();
+  const useWasm = false;
   this.timeout(900000);
 
   let maciAddresses: IMaciContracts;

--- a/packages/testing/ts/__tests__/integration.test.ts
+++ b/packages/testing/ts/__tests__/integration.test.ts
@@ -52,7 +52,7 @@ import {
   POLL_STATE_TREE_DEPTH,
 } from "../constants";
 import { type ITestSuite } from "../types";
-import { expectTally, generateTestUserCommands, isArm, writeBackupFile, backupFolder } from "../utils";
+import { expectTally, generateTestUserCommands, writeBackupFile, backupFolder } from "../utils";
 
 chai.use(chaiAsPromised);
 
@@ -67,7 +67,7 @@ describe("Integration tests", function test() {
   this.timeout(10000000);
 
   // check on which system we are running
-  const useWasm = isArm();
+  const useWasm = false;
 
   // global variables we need shared between tests
   let maciState: MaciState;

--- a/packages/testing/ts/__tests__/keyChange.test.ts
+++ b/packages/testing/ts/__tests__/keyChange.test.ts
@@ -18,7 +18,6 @@ import {
   timeTravel,
   type IGenerateProofsArgs,
   type ITallyData,
-  isArm,
   deployMaci,
   type IMaciContracts,
   deployFreeForAllSignUpPolicy,
@@ -64,7 +63,7 @@ import {
 import { clean, getBackupFilenames, relayTestMessages } from "../utils";
 
 describe("keyChange tests", function test() {
-  const useWasm = isArm();
+  const useWasm = false;
   this.timeout(900000);
 
   let maciAddresses: IMaciContracts;

--- a/packages/testing/ts/__tests__/stress/stress.full.test.ts
+++ b/packages/testing/ts/__tests__/stress/stress.full.test.ts
@@ -14,7 +14,6 @@ import {
   generateProofs,
   deployVerifyingKeysRegistryContract,
   timeTravel,
-  isArm,
   deployMaci,
   deployFreeForAllSignUpPolicy,
   deployConstantInitialVoiceCreditProxy,
@@ -52,22 +51,22 @@ import {
   testTallyVotesFullWasmPath,
   testProcessMessageFullZkeyPath,
   testTallyVotesFullZkeyPath,
-  testVoteTallyNonQvZkeyPath,
-  testProcessMessageNonQvZkeyPath,
-  testProcessMessagesNonQvWitnessPath,
-  testProcessMessagesNonQvWitnessDatPath,
-  testVoteTallyNonQvWitnessPath,
-  testVoteTallyNonQvWitnessDatPath,
-  testProcessMessagesNonQvWasmPath,
-  testVoteTallyNonQvWasmPath,
-  testTallyVotesZkeyPath,
-  testProcessMessageZkeyPath,
-  testProcessMessagesWitnessPath,
-  testProcessMessagesWitnessDatPath,
-  testTallyVotesWitnessPath,
-  testTallyVotesWitnessDatPath,
-  testProcessMessagesWasmPath,
-  testTallyVotesWasmPath,
+  // testVoteTallyNonQvZkeyPath,
+  // testProcessMessageNonQvZkeyPath,
+  // testProcessMessagesNonQvWitnessPath,
+  // testProcessMessagesNonQvWitnessDatPath,
+  // testVoteTallyNonQvWitnessPath,
+  // testVoteTallyNonQvWitnessDatPath,
+  // testProcessMessagesNonQvWasmPath,
+  // testVoteTallyNonQvWasmPath,
+  // testTallyVotesZkeyPath,
+  // testProcessMessageZkeyPath,
+  // testProcessMessagesWitnessPath,
+  // testProcessMessagesWitnessDatPath,
+  // testTallyVotesWitnessPath,
+  // testTallyVotesWitnessDatPath,
+  // testProcessMessagesWasmPath,
+  // testTallyVotesWasmPath,
 } from "../../constants";
 import { clean } from "../../utils";
 
@@ -83,30 +82,30 @@ const filePerMode = {
     voteTallyWasm: testTallyVotesFullWasmPath,
   },
 
-  [EMode.NON_QV]: {
-    voteTallyZkey: testVoteTallyNonQvZkeyPath,
-    messageProcessorZkey: testProcessMessageNonQvZkeyPath,
-    messageProcessorWitnessGenerator: testProcessMessagesNonQvWitnessPath,
-    messageProcessorWitnessDatFile: testProcessMessagesNonQvWitnessDatPath,
-    voteTallyWitnessGenerator: testVoteTallyNonQvWitnessPath,
-    voteTallyWitnessDatFile: testVoteTallyNonQvWitnessDatPath,
-    messageProcessorWasm: testProcessMessagesNonQvWasmPath,
-    voteTallyWasm: testVoteTallyNonQvWasmPath,
-  },
+  // [EMode.NON_QV]: {
+  //   voteTallyZkey: testVoteTallyNonQvZkeyPath,
+  //   messageProcessorZkey: testProcessMessageNonQvZkeyPath,
+  //   messageProcessorWitnessGenerator: testProcessMessagesNonQvWitnessPath,
+  //   messageProcessorWitnessDatFile: testProcessMessagesNonQvWitnessDatPath,
+  //   voteTallyWitnessGenerator: testVoteTallyNonQvWitnessPath,
+  //   voteTallyWitnessDatFile: testVoteTallyNonQvWitnessDatPath,
+  //   messageProcessorWasm: testProcessMessagesNonQvWasmPath,
+  //   voteTallyWasm: testVoteTallyNonQvWasmPath,
+  // },
 
-  [EMode.QV]: {
-    voteTallyZkey: testTallyVotesZkeyPath,
-    messageProcessorZkey: testProcessMessageZkeyPath,
-    messageProcessorWitnessGenerator: testProcessMessagesWitnessPath,
-    messageProcessorWitnessDatFile: testProcessMessagesWitnessDatPath,
-    voteTallyWitnessGenerator: testTallyVotesWitnessPath,
-    voteTallyWitnessDatFile: testTallyVotesWitnessDatPath,
-    messageProcessorWasm: testProcessMessagesWasmPath,
-    voteTallyWasm: testTallyVotesWasmPath,
-  },
+  // [EMode.QV]: {
+  //   voteTallyZkey: testTallyVotesZkeyPath,
+  //   messageProcessorZkey: testProcessMessageZkeyPath,
+  //   messageProcessorWitnessGenerator: testProcessMessagesWitnessPath,
+  //   messageProcessorWitnessDatFile: testProcessMessagesWitnessDatPath,
+  //   voteTallyWitnessGenerator: testTallyVotesWitnessPath,
+  //   voteTallyWitnessDatFile: testTallyVotesWitnessDatPath,
+  //   messageProcessorWasm: testProcessMessagesWasmPath,
+  //   voteTallyWasm: testTallyVotesWasmPath,
+  // },
 };
 
-const numberSignups = 100;
+const numberSignups = 10;
 const numberMessagesPerUser = 2;
 const pollDuration = 900_000;
 
@@ -115,7 +114,7 @@ Object.entries(filePerMode).forEach((data) => {
   const files = data[1];
 
   describe(`stress tests ${EMode[mode]}`, function test() {
-    const useWasm = isArm();
+    const useWasm = false;
     this.timeout(pollDuration);
 
     let maciAddresses: IMaciContracts;
@@ -277,7 +276,7 @@ Object.entries(filePerMode).forEach((data) => {
         }
       });
 
-      it("should generate zk-SNARK proofs and verify them", async () => {
+      it.skip("should generate zk-SNARK proofs and verify them", async () => {
         await timeTravel({ seconds: pollDuration, signer });
         await mergeSignups({ ...mergeSignupsArgs, maciAddress: maciAddresses.maciContractAddress, signer });
         const { tallyData: tallyFileData } = await generateProofs({

--- a/packages/testing/ts/__tests__/unit/joinPoll.test.ts
+++ b/packages/testing/ts/__tests__/unit/joinPoll.test.ts
@@ -33,9 +33,8 @@ import {
   pollDuration,
   verifyingKeysArgs,
 } from "../../constants";
-import { isArm } from "../../utils";
 
-const useWasm = isArm();
+const useWasm = false;
 
 describe("joinPoll", function test() {
   let signer: Signer;

--- a/packages/testing/ts/testingClass.ts
+++ b/packages/testing/ts/testingClass.ts
@@ -32,7 +32,6 @@ import {
   POLL_STATE_TREE_DEPTH,
 } from "./constants";
 import { User } from "./user";
-import { isArm } from "./utils";
 
 /**
  * A class that represents the testing class used in MACI tests
@@ -216,7 +215,7 @@ export class TestingClass {
       signer,
     });
 
-    const useWasm = isArm();
+    const useWasm = false;
 
     const { pollStateIndex, voiceCredits } = await joinPoll({
       maciAddress: maciAddresses.maciContractAddress,


### PR DESCRIPTION
# Description

Check is we can use rapidsnark for macos

## Additional Notes

MacOS github actions use wasm prover for tests and it causes tests to fail with memory issues

## Related issue(s)

N/A

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I ran and verified that all tests pass according to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
