### PR TITLE
chore(website): coordinator docs and blog

### DIFF
--- a/apps/website/blog/2025-09-05-maci-coordinator-service.md
+++ b/apps/website/blog/2025-09-05-maci-coordinator-service.md
@@ -1,0 +1,167 @@
+---
+slug: maci-coordinator-service
+title: MACI Coordinator Service
+description: Announcing our coordinator service for MACI
+authors:
+  - name: ctrlc03
+    title: MACI former team lead
+    url: https://x.com/ctrlc03
+    image_url: https://avatars.githubusercontent.com/u/93448202?v=4c
+  - name: NicoSerranoP
+    title: MACI team member
+    url: https://x.com/NicoSerranoP
+    image_url: https://avatars.githubusercontent.com/u/38594836?v=4
+tags: [voting, security, anonymity, MACI, coordinator]
+excerpt: "A MACI plugin for Aragon OSx to enable private voting in DAOs"
+---
+
+Hey Anon,
+
+Welcome back to our MACI blog.
+
+Today, we are excited to officially announce something we have referenced frequently: the Coordinator Service.
+
+If you ever used MACI, for instance to run a Retroactive Public Goods Funding (RPGF) or Quadratic Funding (QF) round, you might be aware of how tedious it was to operate. The manual process of running scripts to finalise a round and calculate the tally as well as all of the zk-SNARK proofs could require some time and technical expertise. All these steps had to be done in the terminal and you needed to be familiar with MACI's inner workings to understand the process.
+
+**Fear no more - the coordinator service is here to make your life easier.**
+
+## The vision: MACI for everyone
+
+Our goal is ambitious, yet simple: **completely eliminate the need for any technical knowledge to use MACI**. No more terminal commands, no more manual proof generation, no more complex scripts. Just configure once, run inside a Docker container on your server, and enjoy the full power of MACI's privacy-preserving voting infrastructure.
+
+## Technical implementation
+
+The service was built with the following technologies for reliability and scalability:
+
+- TypeScript for type-safe, maintainable code
+- Nest.js framework for enterprise-grade architecture
+- REST API for standard CRUD operations
+- WebSocket endpoints for real-time updates during intensive computations
+- MACI SDK package to have all the logic and functions ready to use
+- Docker-ready for simple deployment anywhere
+
+The core functionalities of the service are as follows:
+
+- Deploy a MACI [subgraph](https://github.com/privacy-scaling-explorations/maci/tree/dev/apps/coordinator/ts/subgraph) to query on-chain data easily
+- [Deploy](https://github.com/privacy-scaling-explorations/maci/tree/dev/apps/coordinator/ts/deployer) the MACI smart contracts, including polls
+- [Finalise](https://github.com/privacy-scaling-explorations/maci/tree/dev/apps/coordinator/ts/proof) polls by processing votes and tallying the results
+- [Schedule](https://github.com/privacy-scaling-explorations/maci/tree/main/apps/coordinator/ts/scheduler) polls for automatic finalization when the voting period ends
+- [Health](https://github.com/privacy-scaling-explorations/maci/tree/main/apps/coordinator/ts/health) endpoint to check everything is setup and working
+
+Let's dive into more details in the following sections.
+
+### Subraph deployment
+
+The endpoint to deploy a subgraph requires some configuration in the `.env` file, as well as an HTTP request to the endpoint responsible for this `https://coordinator.maci.vote/v1/subgraph/deploy`. Make sure you have an account in [The Graph](https://thegraph.com/studio/) to setup your `.env` file before starting the coordinator service.
+
+### Contracts deployment
+
+There are two endpoints in this module: deploy maci (`https://coordinator.maci.vote/v1/deploy/maci`) and deploy poll (`https://coordinator.maci.vote/v1/deploy/poll`). This will take care of all contracts deployment and configuration. It is worth pointing out that you should read the [coordinator service API documentation](https://coordinator.maci.vote/api) and the [MACI guides](https://maci.pse.dev/docs/core-concepts/workflow) to understand the roles of each contract (MACI, poll, policy, initialVoiceCredit).
+
+You can deploy one MACI contract (and its internal smart contracts) that will have one gatekeeper policy (e.g. FreeForAll) for all voters to sign up. After that you can deploy multiple polls with different settings (start date, end date, gatekeeper policy, etc). Each voter will have to join each poll to be eligible to participate in. The poll's gatekeeper will check the voter eligibility to join the poll.
+
+### Finalisation
+
+This step includes three separate actions:
+
+1. Merge - calculate the state merkle tree root and store a commitment to its root (`https://coordinator.maci.vote/v1/proof/merge`)
+2. Process - fetch all smart contracts events to reconstruct the state locally and process all votes. This includes decrypting votes, checking validity, and finally tallying them. zk-SNARK proofs are generated for each batch of votes processed (`https://coordinator.maci.vote/v1/proof/generate`)
+3. Submit - submitting all of the zk-SNARK proofs on chain to prove that the poll was processed correctly. Finally, submit the tally results on chain so that they can be seen by everyone (`https://coordinator.maci.vote/v1/proof/submit`)
+
+We chose to separate each action into its own endpoint to avoid long-running computations that could lead to network errors or timeouts.
+
+### Schedule
+
+After finishing up the finalisation module, we realized that it would be a lot easier for users to create polls and schedule the finalization process. This removes the need for users to manually call the finalization endpoints described above.
+
+1. To schedule a deployed poll you can use `https://coordinator.maci.vote/v1/scheduler/register`.
+2. To check if a poll is scheduled you can use `https://coordinator.maci.vote/v1/scheduler/status`
+3. To delete a scheduled poll you can use `https://coordinator.maci.vote/v1/scheduler/delete`
+
+## How to use
+
+### Run it from source
+
+1. Clone the MACI repository: [https://github.com/privacy-scaling-explorations/maci](https://github.com/privacy-scaling-explorations/maci)
+2. Install dependencies and build the project
+
+```bash
+pnpm install
+pnpm run build
+```
+
+3. Download the zkeys for the coordinator
+
+```bash
+pnpm run download-zkeys:ceremony:coordinator
+```
+
+4. Generate a coordinator MACI keypair. Remember to store those values for later.
+
+```bash
+pnpm run generate-maci-keypair
+```
+
+5. Move to the coordinator service directory
+
+```bash
+cd apps/coordinator
+```
+
+6. Configure your `.env` file. Make sure to configure it with your own secure values. The coordinator MACI private key from the previous step should be set here
+
+```bash
+cp .env.example .env
+```
+
+7. Start the service
+
+```bash
+pnpm run start
+# or
+pnpm run start:prod
+```
+
+### Run it with Docker
+
+1. Clone the MACI repository: [https://github.com/privacy-scaling-explorations/maci](https://github.com/privacy-scaling-explorations/maci)
+2. Go inside the project directory
+
+```bash
+cd maci
+```
+
+3. Build the docker image and run the container
+
+```bash
+# Build docker
+docker compose -f apps/coordinator/docker-compose.yml build
+
+# Run container detached
+docker compose -f apps/coordinator/docker-compose.yml up -d
+```
+
+## Usage notes
+
+1. You can check out the documentation while the service is running in [http://localhost:3001/api](http://localhost:3001/api)
+
+2. We have a [e2e.deploy.test.ts](https://github.com/privacy-scaling-explorations/maci/blob/main/apps/coordinator/tests/e2e.deploy.test.ts) file that performs a complete process: deployment, voting and finalization. You can use it to guide yourself.
+
+## Future work
+
+We are researching about different cryptographic methods to decentralize the coordinator. The idea is to eliminate reliance on a single centralized service for finalizing polls. A group of people would be able to spin up their own coordinator services and finalize the poll in a multi-party computation. For more info check out our MACI v4 research.
+
+## Conclusion
+
+The MACI Coordinator Service represents a significant leap forward in making MACI accessible to everyone. Whether you're running a small community poll or a large-scale funding round, the coordinator service handles the complexity so you can focus on what matters - empowering your community with private, secure voting.
+
+Ready to get started? Head over to our documentation and deploy your first MACI round today!
+
+Please reach out if you would like to integrate the service into your frontend.
+
+## References
+
+- [MACI repo](https://github.com/privacy-scaling-explorations/maci)
+- [Sample frontend](https://github.com/privacy-scaling-explorations/maci-aragon-osx-gov-app) using the coordinator service
+- [Code examples](https://github.com/privacy-scaling-explorations/maci-aragon-osx-gov-app/blob/main/plugins/maciVoting/contexts/CoordinatorContext.tsx)
+- [Documentation](https://maci.pse.dev/docs/category/coordinator-service)

--- a/apps/website/versioned_docs/version-v3.x/technical-references/coordinator-service/index.md
+++ b/apps/website/versioned_docs/version-v3.x/technical-references/coordinator-service/index.md
@@ -7,4 +7,18 @@ sidebar_position: 1
 
 # Coordinator Service
 
-Welcome to the Coordinator Service technical reference. Here you will find the technical details of the Coordinator Service, including the API endpoints and code examples.
+Welcome to the Coordinator Service technical reference. This guide describes how the Coordinator Service works, its workflow, and how to interact with it. For more technical code documentation regarding API endpoints and data transfer objects, please refer to the [API documentation](https://coordinator.maci.vote/api).
+
+## Responsibilities
+
+A MACI coordinator is responsible for running voting processes. In quadratic funding rounds or authority election rounds, the coordinator is the entity that defines who can vote, which projects or candidates are eligible for funding, and the duration of the voting round.
+
+First of all, the coordinator needs to deploy the MACI smart contracts with the desired configuration: gatekeeper policy, which defines who can sign up as a voter; the state Merkle tree depth which defines the maximum number of voters; and the voting mode which defines how votes will be counted (more info in [Poll types](https://maci.pse.dev/docs/core-concepts/poll-types#quadratic-voting)).
+
+After deploying the MACI contracts, the coordinator can deploy a poll (which represents a voting process). To deploy the poll, the coordinator needs to specify: the gatekeeper policy, which defines who can join the poll as a voter; the start and end dates of the poll; the number of options to vote for; the maximum number of votes per voter; and the voting mode.
+
+The coordinator will then wait until the poll ends, after which they will need to finalize the poll. This involves processing all published messages, extracting the votes, tallying them, and submitting the results on-chain.
+
+## Conclusion
+
+In the following documents, we will go through the details of setting up the Coordinator Service and how to interact with it to perform the tasks described above.

--- a/apps/website/versioned_docs/version-v3.x/technical-references/coordinator-service/installation.md
+++ b/apps/website/versioned_docs/version-v3.x/technical-references/coordinator-service/installation.md
@@ -5,39 +5,11 @@ sidebar_label: Installation
 sidebar_position: 2
 ---
 
-1. Add `.env` file (see `.env.example`).
-2. Generate RSA key pair with `pnpm run generate-keypair`.
-3. Download zkey files using `pnpm run download-zkeys:{type}` (only test type is available for now).
-4. Make sure you copied RSA public key to your application. This will be needed for encrypting `Authorization` header and coordinator private key for proof generation. Also it can be accessed through API method `GET v1/proof/publicKey`.
-5. Run `pnpm run start` to run the service.
-6. All API calls must be called with `Authorization` header, where the value is encrypted with RSA public key you generated before. Header value contains message signature and message digest created by `COORDINATOR_ADDRESSES`. The format is `publicEncrypt({signature}:{digest})`.
-   Make sure you set `COORDINATOR_ADDRESSES` env variable and sign any message with the addresses from your application (see [AccountSignatureGuard](./ts/auth/AccountSignatureGuard.service.ts)).
-7. Proofs can be generated with `POST v1/proof/generate` API method or with Websockets (see [dto spec](./ts/proof/dto.ts), [controller](./ts/app.controller.ts) and [wsgateway](./ts/events/events.gateway.ts)).
+There are two ways to run the coordinator service: building it from source or using Docker. Both methods require you to clone the MACI repository and move to the project root directory.
 
-## Subgraph deployment
-
-It is possible to deploy subgraph using coordinator service.
-
-First, you need to setup subgraph and create a project. [Subgraph dashboard](https://thegraph.com/studio/).
-
-Then, set env variables:
-
-```
-# Subgraph name
-SUBGRAPH_NAME="maci-subgraph"
-
-# Subgraph provider url
-SUBGRAPH_PROVIDER_URL=https://api.studio.thegraph.com/deploy/
-
-# Subgraph deploy key
-SUBGRAPH_DEPLOY_KEY=*******
-
-# Subgraph project folder
-SUBGRAPH_FOLDER=../subgraph
+```bash
+git clone https://github.com/privacy-scaling-explorations/maci
+cd maci
 ```
 
-After deployment, subgraph url will be available in studio dashboard and you can use this type of url to get latest deployed version in your application:
-
-```
-https://api.studio.thegraph.com/.../{SUBGRAPH_NAME}/version/latest
-```
+You need to check the latest [README.md](https://github.com/privacy-ethereum/maci/tree/main/apps/coordinator) instructions in the coordinator service app for detailed information about requirements and steps to install, build, and run the service.

--- a/apps/website/versioned_docs/version-v3.x/technical-references/coordinator-service/usage.md
+++ b/apps/website/versioned_docs/version-v3.x/technical-references/coordinator-service/usage.md
@@ -1,0 +1,64 @@
+---
+title: Usage
+description: Learn how to interact with a running MACI coordinator service instance.
+sidebar_label: Usage
+sidebar_position: 3
+---
+
+After setting up and running the MACI coordinator service, you can interact with it through its RESTful API. The service provides various endpoints for deployment and finalization of polls. Please refer to the API documentation at [https://coordinator.maci.vote/api](https://coordinator.maci.vote/api) for the exact request format and required parameters for all endpoint calls described below.
+
+# Authentication
+
+The coordinator service uses a custom signature authentication mechanism to guard the deploy endpoints. To interact with these endpoints, you need to:
+
+1. Make sure you have run the command to set up and generate the RSA keypair, as described in the instructions section.
+
+2. Ensure that your Ethereum public key is set in the `.env` file under the `COORDINATOR_ADDRESSES` variable.
+
+3. Get the RSA public key from the coordinator service with [https://coordinator.maci.vote/v1/proof/publicKey](https://coordinator.maci.vote/v1/proof/publicKey).
+
+4. Sign a message such as "authenticate-me" using the coordinator's Ethereum private key.
+
+5. Encrypt both the message (also called digest) and its signature using the RSA public key. For example, you can use RSA public-key encryption in the format:
+
+```javascript
+const payload: string = "signature:digest";
+```
+
+Then encrypt this payload using the coordinator’s RSA public key.
+
+# Deploy MACI
+
+To deploy the set of MACI smart contracts, you need to call the endpoint [https://coordinator.maci.vote/v1/deploy/maci](https://coordinator.maci.vote/v1/deploy/maci) with a POST request. The request body should include the necessary parameters for the deployment, such as the gatekeeper policy, state tree depth, and voting mode.
+
+# Deploy Poll
+
+To deploy a new poll to an existing MACI instance, you need to call the endpoint [https://coordinator.maci.vote/v1/deploy/poll](https://coordinator.maci.vote/v1/deploy/poll) with a POST request. The request body should include the necessary parameters for the poll deployment, such as the gatekeeper policy, start and end dates, number of options, and voting mode.
+
+# Deploy Subgraph
+
+To deploy a subgraph for a MACI instance and its corresponding polls, you need to call the endpoint [https://coordinator.maci.vote/v1/subgraph/deploy](https://coordinator.maci.vote/v1/subgraph/deploy) with a POST request. The request body should include the necessary parameters for the subgraph deployment, such as the MACI contract address and the subgraph name.
+
+# Finalize Poll
+
+To finalize a poll, you need to follow a series of steps that involve processing messages, merging state trees, generating proofs, and submitting the final tally on-chain. The Coordinator Service provides endpoints for each of these steps.
+
+## Merge
+
+To merge the published messages and create the required state tree, you need to call the endpoint [https://coordinator.maci.vote/v1/proof/merge](https://coordinator.maci.vote/v1/proof/merge) with a POST request. The request body should include the necessary parameters for the merge operation, such as the MACI contract address and the poll ID.
+
+## Generate
+
+Once the Merkle trees are ready, you can generate the zk-SNARK proof for the final tally by calling the endpoint [https://coordinator.maci.vote/v1/proof/generate](https://coordinator.maci.vote/v1/proof/generate) with a POST request. The request body should include the necessary parameters for the proof generation, such as the MACI contract address and the poll ID.
+
+## Submit
+
+After generating the proof, you can submit the final tally on-chain by calling the endpoint [https://coordinator.maci.vote/v1/proof/submit](https://coordinator.maci.vote/v1/proof/submit) with a POST request. The request body should include the necessary parameters for the submission, such as the MACI contract address, poll ID, and the generated proof.
+
+# Schedule Poll
+
+After deploying a poll, you can schedule it to be finalized automatically after it ends. Make sure to set the MACI coordinator private key in the `.env` file. To do so, you need to call the endpoint [https://coordinator.maci.vote/v1/schedule/poll](https://coordinator.maci.vote/v1/schedule/poll) with a POST request. The request body should include the necessary parameters for scheduling the poll, such as the MACI contract address and the poll ID.
+
+# Health
+
+To check that the env variables are set correctly and the service is running, you can call the health endpoint [https://coordinator.maci.vote/v1/health](https://coordinator.maci.vote/v1/health) with a GET request. This endpoint will return a status message indicating the rapidsnark access, redis database connection, zkeys access, and the MACI coordinator address with its funds in each MACI-compatible network.


### PR DESCRIPTION
# Description

I have added the Coordinator Service docs to the MACI Documentation web and also added the coordinator service blogpost.

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [X] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [X] I ran and verified that all tests pass according to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
