### PR TITLE
fix(coordinator): allow reuse of poseidon addresses

### DIFF
--- a/apps/coordinator/ts/deployer/__tests__/utils.ts
+++ b/apps/coordinator/ts/deployer/__tests__/utils.ts
@@ -45,13 +45,6 @@ export const testMaciDeploymentConfig: IDeployMaciConfig = {
       tallyProcessingStateTreeDepth: "1",
     },
   },
-  Poseidon: {
-    // poseidon contracts on optimism sepolia
-    poseidonT3: "0x07490eba00dc4ACA6721D052Fa4C5002Aa077233",
-    poseidonT4: "0xbb0e724CE02e5E7eDd31e632dc6e59F229a1126d",
-    poseidonT5: "0xE0398F7DFAC494c530F6404AfEaC8669ABeD2679",
-    poseidonT6: "0xfD77833F10a29c76A6a0ede235Eb651D744d0E2F",
-  },
 };
 
 /**

--- a/apps/coordinator/ts/deployer/deployer.service.ts
+++ b/apps/coordinator/ts/deployer/deployer.service.ts
@@ -614,6 +614,7 @@ export class DeployerService {
       stateTreeDepth: config.MACI.stateTreeDepth,
       signer,
       signupPolicyAddress: policyAddress,
+      poseidonAddresses: config.Poseidon,
     });
 
     // store the contracts


### PR DESCRIPTION
# Description

Allow users to send pre-existing deployed contract addresses of poseidon contracts to avoid redeploying them again. Please be sure that the nightly coordinator e2e tests are working correctly before merging this.

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [X] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [X] I ran and verified that all tests pass according to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
