### PR TITLE
fix: set default port to 3001

### DIFF
--- a/apps/coordinator/.env.example
+++ b/apps/coordinator/.env.example
@@ -48,7 +48,7 @@ COORDINATOR_ADDRESSES=
 COORDINATOR_ALLOWED_ORIGINS=
 
 # Specify port for coordinator service (optional)
-COORDINATOR_PORT=
+COORDINATOR_PORT=3001
 
 # Redis configuration
 COORDINATOR_REDIS_HOST="localhost"

--- a/apps/coordinator/tests/e2e.deploy.test.ts
+++ b/apps/coordinator/tests/e2e.deploy.test.ts
@@ -40,7 +40,7 @@ dotenv.config();
 
 jest.setTimeout(700000); // Sets timeout to 700 seconds
 
-const PORT = process.env.COORDINATOR_PORT || 3000;
+const PORT = process.env.COORDINATOR_PORT || 3001;
 const TEST_URL = `http://localhost:${PORT}/v1`;
 const CHAIN = ESupportedChains.Localhost;
 

--- a/apps/coordinator/ts/main.ts
+++ b/apps/coordinator/ts/main.ts
@@ -49,7 +49,7 @@ async function bootstrap() {
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup("api", app, document);
 
-  await app.listen(process.env.COORDINATOR_PORT || 3000);
+  await app.listen(process.env.COORDINATOR_PORT || 3001);
 }
 
 bootstrap();


### PR DESCRIPTION
# Description

Docker compose [file](https://github.com/privacy-ethereum/maci/blob/509b0e08c434199ae9df51fb25f73e1aa3c4d5be/apps/coordinator/docker-compose.yml#L29) assumes port is 3001, this PR just brings the default port values in with that assumption

## Additional Notes

<!-- If there are any additional notes, requirements or special instructions related to this PR, please specify them here. -->

## Related issue(s)

<!-- Please list here with closing keywords any issues that this pull request is related to (fix #$ISSUE_NUMBER). -->

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I ran and verified that all tests pass according to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
