### PR TITLE
fix: disable stress testing for macos nightly job

### DIFF
--- a/.github/workflows/nightly-mac.yml
+++ b/.github/workflows/nightly-mac.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        command: ["test", "test:unit", "test:integration", "test:e2e", "test:stress", "test:hardhat"]
+        command: ["test", "test:unit", "test:integration", "test:e2e", "test:hardhat"]
 
     runs-on: macos-14
 


### PR DESCRIPTION
# Description

Running stress tests is not supported for macos due to memory issues with wasm prover.
Rapidsnark is not supported for macos but the same stress tests are passed for ubuntu (rapidsnark).

## Additional Notes

When rapidsnark works properly we can return it back, right now it's just an always falling task.

## Related issue(s)

Related #838 

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I ran and verified that all tests pass according to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
