### PR TITLE
chore: update copyright year to 2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Ethereum Foundation
+Copyright (c) 2026 Ethereum Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Happy New Year!

## Changes
Updates the copyright year in license files from 2025 to 2026.

This is a routine annual update to keep the copyright notices current.