### PR TITLE
feat(sdk,cli): add isOpen status to poll data and improve CLI output

### DIFF
--- a/packages/cli/ts/index.ts
+++ b/packages/cli/ts/index.ts
@@ -643,7 +643,7 @@ program
       });
       const privateKey = args.privateKey || (await promptSensitiveValue("Insert your MACI private key"));
 
-      await publish({
+      const { hash } = await publish({
         publicKey: args.publicKey,
         stateIndex: args.stateIndex,
         voteOptionIndex: args.voteOptionIndex,
@@ -654,6 +654,11 @@ program
         salt: args.salt,
         privateKey,
         signer,
+      });
+
+      logGreen({
+        quiet: args.quiet,
+        text: success(`Message published successfully. Transaction hash: ${hash}`),
       });
     } catch (error) {
       program.error((error as Error).message, { exitCode: 1 });
@@ -877,6 +882,7 @@ program
   .description("Get deployed poll from MACI contract")
   .option("-p, --poll <poll>", "the poll id")
   .option("-x, --maci-address <maciAddress>", "the MACI contract address")
+  .option("-q, --quiet <quiet>", "whether to print values to the console", (value) => value === "true", false)
   .action(async (args) => {
     try {
       const signer = await getSigner();
@@ -900,13 +906,16 @@ program
         [EMode.FULL]: "Full Credits Voting",
       };
 
+      const status = details.isOpen ? "Open" : "Closed";
+
       logGreen({
-        quiet: true,
+        quiet: args.quiet,
         text: success(
           [
             `ID: ${details.id}`,
             `Start time: ${new Date(Number(details.startDate) * 1000).toString()}`,
             `End time: ${new Date(Number(details.endDate) * 1000).toString()}`,
+            `Status: ${status}`,
             `Number of signups ${details.totalSignups}`,
             `State tree merged: ${details.isMerged}`,
             `Mode: ${modeNames[details.mode as EMode]}`,
@@ -988,6 +997,8 @@ program
         totalVoteOptions: pollParams.totalVoteOptions,
         voteOptionTreeDepth: pollParams.voteOptionTreeDepth,
       });
+
+      logGreen({ quiet: args.quiet, text: success("The tally commitment is correct") });
     } catch (error) {
       program.error((error as Error).message, { exitCode: 1 });
     }

--- a/packages/sdk/ts/poll/poll.ts
+++ b/packages/sdk/ts/poll/poll.ts
@@ -18,16 +18,22 @@ export const getPoll = async ({ maciAddress, signer, provider, pollId }: IGetPol
     tally: tallyContract,
   } = await getPollContracts({ maciAddress, pollId, signer, provider });
 
-  const [[startDate, endDate], mergedStateRoot, pollAddress] = await Promise.all([
+  const signerOrProvider = signer ?? provider!;
+  const [[startDate, endDate], mergedStateRoot, pollAddress, block] = await Promise.all([
     pollContract.getStartAndEndDate(),
     pollContract.mergedStateRoot(),
     pollContract.getAddress(),
+    signerOrProvider.provider!.getBlock("latest"),
   ]);
   const isMerged = mergedStateRoot !== 0n;
   const totalSignups = await pollContract.totalSignups();
 
   // get the poll mode
   const mode = await tallyContract.mode();
+
+  // determine if the poll is currently open for voting
+  const currentTime = BigInt(block!.timestamp);
+  const isOpen = currentTime >= startDate && currentTime <= endDate;
 
   return {
     id,
@@ -36,6 +42,7 @@ export const getPoll = async ({ maciAddress, signer, provider, pollId }: IGetPol
     endDate,
     totalSignups,
     isMerged,
+    isOpen,
     mode,
   };
 };

--- a/packages/sdk/ts/poll/types.ts
+++ b/packages/sdk/ts/poll/types.ts
@@ -91,6 +91,11 @@ export interface IGetPollData {
   isMerged: boolean;
 
   /**
+   * Whether the poll is currently open for voting
+   */
+  isOpen: boolean;
+
+  /**
    * Mode of the poll
    */
   mode: BigNumberish;


### PR DESCRIPTION
## Summary
- Added `isOpen` field to poll data in SDK, calculated by comparing current block timestamp with poll start/end dates
- Added transaction hash output for `publish` command
- Added poll status display (Open/Closed) and `--quiet` option for `getPoll` command
- Added success message for `verifyTallyCommitment` command