### PR TITLE
chore: validate vote option tree depth before indexing emptyBallotRoots

### DIFF
--- a/packages/contracts/contracts/MACI.sol
+++ b/packages/contracts/contracts/MACI.sol
@@ -108,6 +108,7 @@ contract MACI is IMACI, DomainObjs, Params, Hasher {
   error PoseidonHashLibrariesNotLinked();
   error TooManySignups();
   error InvalidPublicKey();
+  error InvalidVoteOptionTreeDepth();
   error PollDoesNotExist(uint256 pollId);
   error UserNotSignedUp();
 
@@ -171,6 +172,9 @@ contract MACI is IMACI, DomainObjs, Params, Hasher {
     if (!CurveBabyJubJub.isOnCurve(args.coordinatorPublicKey.x, args.coordinatorPublicKey.y)) {
       revert InvalidPublicKey();
     }
+
+    uint8 depth = args.treeDepths.voteOptionTreeDepth;
+    if (depth == 0 || depth > emptyBallotRoots.length) revert InvalidVoteOptionTreeDepth();
 
     ExtContracts memory extContracts = ExtContracts({
       maci: IMACI(address(this)),


### PR DESCRIPTION
Adds explicit validation for vote option tree depth before indexing emptyBallotRoots to prevent potential underflow or out-of-bounds panic when an invalid depth is provided.

