### PR TITLE
fix: maci 2 incorrect subgroup check for public key

### DIFF
--- a/packages/circuits/circom/utils/EdDSAPoseidonVerifier.circom
+++ b/packages/circuits/circom/utils/EdDSAPoseidonVerifier.circom
@@ -82,7 +82,7 @@ template EdDSAPoseidonVerifier() {
     // Components to handle edge cases and ensure that all conditions 
     // for a valid signature are met, including the 
     // public key not being zero and other integrity checks.
-    var computedIsAxZero = IsZero()(publicKeyX);
+    var computedIsAxZero = IsZero()(computedDouble3XOut);
     var computedIsAxEqual = IsEqual()([computedIsAxZero, 0]);
     var computedIsCcZero = IsZero()(computedCompConstant);
     var computedIsValid = IsEqual()([computedIsLeftRightValid + computedIsAxEqual + computedIsCcZero, 3]);


### PR DESCRIPTION
# Description

Fixes MACI-2

<!-- Please provide a detailed description of the pull request you are opening. -->

## Additional Notes

<!-- If there are any additional notes, requirements or special instructions related to this PR, please specify them here. -->

## Related issue(s)

<!-- Please list here with closing keywords any issues that this pull request is related to (fix #$ISSUE_NUMBER). -->

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I ran and verified that all tests pass according to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
