### PR TITLE
fix: maci 6 under constrained num2bits

### DIFF
--- a/packages/circuits/circom/utils/EdDSAPoseidonVerifier.circom
+++ b/packages/circuits/circom/utils/EdDSAPoseidonVerifier.circom
@@ -44,7 +44,7 @@ template EdDSAPoseidonVerifier() {
 
     // Ensure signatureScalar<Subgroup Order.
     // convert the signature scalar signatureScalar into its binary representation.
-    var computedNum2Bits[254] = Num2Bits(254)(signatureScalar);
+    var computedNum2Bits[254] = Num2Bits_strict()(signatureScalar);
 
     var computedCompConstantIn[254] = computedNum2Bits;
     computedCompConstantIn[253] = 0;


### PR DESCRIPTION
# Description

Fix for MACI-6

<!-- Please provide a detailed description of the pull request you are opening. -->

## Additional Notes

<!-- If there are any additional notes, requirements or special instructions related to this PR, please specify them here. -->

## Related issue(s)

<!-- Please list here with closing keywords any issues that this pull request is related to (fix #$ISSUE_NUMBER). -->

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I ran and verified that all tests pass according to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
