### PR TITLE
feat(testing): maci #16 use await in test

### DIFF
--- a/packages/testing/ts/__tests__/unit/setVerifyingKeys.test.ts
+++ b/packages/testing/ts/__tests__/unit/setVerifyingKeys.test.ts
@@ -42,12 +42,12 @@ describe("setVerifyingKeys", function test() {
       verifyingKeysRegistryAddress,
     });
 
-    expect(
+    await expect(
       setVerifyingKeys({
         ...(await verifyingKeysArgs(signer, [EMode.NON_QV])),
         verifyingKeysRegistryAddress,
       }),
-    ).rejectedWith("This poll joining verifying key is already set in the contract");
+    ).eventually.rejectedWith("This poll joining verifying key is already set in the contract");
   });
 
   it("should throw when setting different number of modes and different number of process verifying keys", async () => {


### PR DESCRIPTION
# Description

Use await in test.

## Related issue(s)

Fix https://github.com/privacy-ethereum/maci/issues/2850

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [X] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [X] I ran and verified that all tests pass according to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
