### PR TITLE
fix: maci 18 incorrect comments for poll functions

### DIFF
--- a/packages/contracts/contracts/Poll.sol
+++ b/packages/contracts/contracts/Poll.sol
@@ -426,7 +426,7 @@ contract Poll is Clone, Params, Utilities, SnarkCommon, IPoll {
   }
 
   /// @notice Verify the proof for joined Poll
-  /// @param _index Index of the MACI's stateRootOnSignUp when the user signed up
+  /// @param _index Index of the Poll's pollStateRootsOnJoin when the user joined
   /// @param _proof The zk-SNARK proof
   /// @return isValid Whether the proof is valid
   function verifyJoinedPollProof(uint256 _index, uint256[8] memory _proof) public view returns (bool isValid) {
@@ -461,7 +461,7 @@ contract Poll is Clone, Params, Utilities, SnarkCommon, IPoll {
   }
 
   /// @notice Get public circuit inputs for poll joined circuit
-  /// @param _index Index of the MACI's stateRootOnSignUp when the user signed up
+  /// @param _index Index of the Poll's pollStateRootsOnJoin when the user joined
   /// @return publicInputs Public circuit inputs
   function getPublicJoinedCircuitInputs(uint256 _index) public view returns (uint256[] memory publicInputs) {
     publicInputs = new uint256[](1);


### PR DESCRIPTION
# Description

Fixes audit issue 18 (See new report for issue description)

<!-- Please provide a detailed description of the pull request you are opening. -->

## Additional Notes

<!-- If there are any additional notes, requirements or special instructions related to this PR, please specify them here. -->

## Related issue(s)

<!-- Please list here with closing keywords any issues that this pull request is related to (fix #$ISSUE_NUMBER). -->

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I ran and verified that all tests pass according to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
