### PR TITLE
fix: use valid URLs for zkeys

### DIFF
--- a/.github/scripts/downloadZkeys.ts
+++ b/.github/scripts/downloadZkeys.ts
@@ -7,8 +7,8 @@ import path from "path";
 const ZKEY_PATH = path.resolve(process.argv.slice(3)[0]);
 const ZKEYS_URLS = {
   test: "https://maci-develop-fra.s3.eu-central-1.amazonaws.com/v3.0.0/maci_artifacts_v3.0.0_test.tar.gz",
-  prod: "https://maci-develop-fra.s3.eu-central-1.amazonaws.com/v3.0.0/maci_artifacts_prod.tar.gz",
-  large: "https://maci-develop-fra.s3.eu-central-1.amazonaws.com/v3.0.0/maci_artifacts_large.tar.gz",
+  prod: "https://maci-develop-fra.s3.eu-central-1.amazonaws.com/v3.0.0/maci_artifacts_v3.0.0_prod.tar.gz",
+  large: "https://maci-develop-fra.s3.eu-central-1.amazonaws.com/v3.0.0/maci_artifacts_v3.0.0_large.tar.gz",
 };
 const ARCHIVE_NAME = path.resolve(ZKEY_PATH, "maci_keys.tar.gz");
 


### PR DESCRIPTION
# Description

I just realized that the zkeys URLs were not accessible and the slug was incorrect. This PR fixes it.

## Additional Notes

<!-- If there are any additional notes, requirements or special instructions related to this PR, please specify them here. -->

## Related issue(s)

<!-- Please list here with closing keywords any issues that this pull request is related to (fix #$ISSUE_NUMBER). -->

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [X] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [X] I ran and verified that all tests pass according to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
