### PR TITLE
docs: update v3 poll mode configuration examples

### DIFF
--- a/apps/website/versioned_docs/version-v3.x/core-concepts/poll-types.md
+++ b/apps/website/versioned_docs/version-v3.x/core-concepts/poll-types.md
@@ -17,13 +17,13 @@ To run a poll with quadratic voting, the coordinator must deploy the Poll with t
 
 ### Using Hardhat tasks
 
-In the deploy-config.json file set the `mode` value to **qv**.
+In the deploy-config.json file set the `mode` value to `0`.
 
 ```json
 "Poll": {
     "pollDuration": 604800,
     "coordinatorPublicKey": "macipk",
-    "mode": "qv"
+    "mode": 0
 }
 ```
 
@@ -37,17 +37,17 @@ pnpm deploy-poll:NETWORK
 
 The non quadratic voting option is a new feature that has been added to MACI with the v1.2 release. It allows to conduct polls without the quadratic voting mechanism. This means that the number of voice credits is not reduced by the square of the weight of the vote casted. This option is useful for polls where the quadratic voting mechanism is not necessary, and it is also slightly cheaper for coordinators to tally votes, as there are less checks required in the Tally smart contract.
 
-To run a poll with non quadratic voting, the coordinator must set the `mode` parameter to `non-qv` when creating the MACI instance. This will make the MACI instance use the `TallyNonQv` smart contract, which is a smaller version of the `Tally` smart contract, as it does not require the checks for the quadratic voting mechanism.
+To run a poll with non quadratic voting, the coordinator must set the `mode` parameter to `1` when deploying the poll. This will make the MACI instance use the `TallyNonQv` smart contract, which is a smaller version of the `Tally` smart contract, as it does not require the checks for the quadratic voting mechanism.
 
 ### Using Hardhat tasks
 
-In the deploy-config.json file set the `mode` value to **non-qv**.
+In the deploy-config.json file set the `mode` value to `1`.
 
 ```json
 "Poll": {
     "pollDuration": 604800,
     "coordinatorPublicKey": "macipk",
-    "mode": "non-qv"
+    "mode": 1
 }
 ```
 
@@ -61,17 +61,17 @@ pnpm deploy-poll:NETWORK
 
 Full Credits Voting is a new feature introduced in MACI v3. This voting mode disables the quadratic voting mechanism and requires participants to allocate their entire voice credit balance to a single option. Unlike quadratic voting, where the cost of votes increases quadratically with the number of votes cast, Full Credits Voting uses a linear model: participants spend all their available voice credits on one chosen option. No splitting across multiple options is allowed. This option is useful for polls where the quadratic voting mechanism is not necessary and where it's important to ensure voters fully commit to a single choice—eliminating fragmented or spread-out voting behavior. It also offers a slight cost advantage for coordinators, as tallying is more efficient with fewer checks required in the Tally smart contract.
 
-To run a poll full credits voting, the coordinator must set the `mode` parameter to `full` when creating the MACI instance. This will make the MACI instance use the `TallyNonQv` smart contract, which is a smaller version of the `Tally` smart contract, as it does not require the checks for the quadratic voting mechanism.
+To run a poll with full credits voting, the coordinator must set the `mode` parameter to `2` when deploying the poll. This will make the MACI instance use the `TallyNonQv` smart contract, which is a smaller version of the `Tally` smart contract, as it does not require the checks for the quadratic voting mechanism.
 
 ### Using Hardhat tasks
 
-In the deploy-config.json file set the `mode` value to **full**.
+In the deploy-config.json file set the `mode` value to `2`.
 
 ```json
 "Poll": {
     "pollDuration": 604800,
     "coordinatorPublicKey": "macipk",
-    "mode": "full"
+    "mode": 2
 }
 ```
 

--- a/apps/website/versioned_docs/version-v3.x/core-concepts/polls.md
+++ b/apps/website/versioned_docs/version-v3.x/core-concepts/polls.md
@@ -24,7 +24,7 @@ The full configuration for a poll looks like this:
     "pollStartDate": 3600,
     "pollEndDate": 3600,
     "coordinatorPublicKey": "macipk.9a59264310d95cfd8eb7083aebeba221b5c26e77427f12b7c0f50bc1cc35e621",
-    "useQuadraticVoting": false,
+    "mode": 1,
     "policy": "FreeForAllPolicy",
     "relayers": "0x0000000000000000000000000000000000000000",
     "initialVoiceCreditProxy": "ConstantInitialVoiceCreditProxy",
@@ -40,13 +40,13 @@ To run a poll with quadratic voting, the coordinator must deploy the Poll with t
 
 ### Using Hardhat tasks
 
-In the deploy-config.json file set the `mode` value to **qv**.
+In the deploy-config.json file set the `mode` value to `0`.
 
 ```json
 "Poll": {
     [...]
     "coordinatorPublicKey": "macipk",
-    "mode": "qv"
+    "mode": 0
 }
 ```
 
@@ -60,17 +60,17 @@ pnpm deploy-poll:NETWORK
 
 The non quadratic voting option is a new feature that has been added to MACI with the v1.2 release. It allows to conduct polls without the quadratic voting mechanism. This means that the number of voice credits is not reduced by the square of the weight of the vote casted. This option is useful for polls where the quadratic voting mechanism is not necessary, and it is also slightly cheaper for coordinators to tally votes, as there are less checks required in the Tally smart contract.
 
-To run a poll with non quadratic voting, the coordinator must set the `mode` parameter to `non-qv` when creating the MACI instance.
+To run a poll with non quadratic voting, the coordinator must set the `mode` parameter to `1` when deploying the poll.
 
 ### Using Hardhat tasks
 
-In the deploy-config.json file set the `mode` value to **non-qv**.
+In the deploy-config.json file set the `mode` value to `1`.
 
 ```json
 "Poll": {
     [...]
     "coordinatorPublicKey": "macipk",
-    "mode": "non-qv"
+    "mode": 1
 }
 ```
 
@@ -84,17 +84,17 @@ pnpm deploy-poll:NETWORK
 
 Full Credits Voting is a new feature introduced in MACI v3. This voting mode disables the quadratic voting mechanism and requires participants to allocate their entire voice credit balance to a single option. Unlike quadratic voting, where the cost of votes increases quadratically with the number of votes cast, Full Credits Voting uses a linear model: participants spend all their available voice credits on one chosen option. No splitting across multiple options is allowed. This option is useful for polls where the quadratic voting mechanism is not necessary and where it's important to ensure voters fully commit to a single choice—eliminating fragmented or spread-out voting behavior. It also offers a slight cost advantage for coordinators, as tallying is more efficient with fewer checks required in the Tally smart contract.
 
-To run a poll with full credits voting, the coordinator must set the `mode` parameter to `full` when creating the MACI instance.
+To run a poll with full credits voting, the coordinator must set the `mode` parameter to `2` when deploying the poll.
 
 ### Using Hardhat tasks
 
-In the deploy-config.json file set the `mode` value to **full**.
+In the deploy-config.json file set the `mode` value to `2`.
 
 ```json
 "Poll": {
     [...]
     "coordinatorPublicKey": "macipk",
-    "mode": "full"
+    "mode": 2
 }
 ```
 

--- a/apps/website/versioned_docs/version-v3.x/quick-start.md
+++ b/apps/website/versioned_docs/version-v3.x/quick-start.md
@@ -157,7 +157,7 @@ The recommended values for test keys are: **10-1-2-2-1**. For ceremony keys: **1
 | **pollStartDate**           | Defines when the poll starts in seconds.                          |
 | **pollEndDate**             | Defines how long is going to be the poll in seconds.              |
 | **coordinatorPublicKey**    | Defines the coordinator public MACI key.                          |
-| **useQuadraticVoting**      | Defines if the poll uses quadratic voting or not.                 |
+| **mode**                    | Defines the voting mode: `0` QV, `1` non-QV, `2` full credits.    |
 | **policy**                  | Defines the policy of the poll.                                   |
 | **relayers**                | Defines an array of addresses that are allowed to relay messages. |
 | **initialVoiceCreditProxy** | Defines the type of voice credit proxy to use for this poll.      |


### PR DESCRIPTION
# Description


- Replace the outdated `useQuadraticVoting` poll config property with `mode` in the v3.x quick start docs.
- Update v3.x poll examples to use the numeric `mode` values expected by the deploy config:
  - `0` for QV
  - `1` for non-QV
  - `2` for full credits voting
- Keep the duplicate poll type examples in sync with the same numeric values.

Fixes #2826.



## Additional Notes

<!-- If there are any additional notes, requirements or special instructions related to this PR, please specify them here. -->

## Related issue(s)

<!-- Please list here with closing keywords any issues that this pull request is related to (fix #$ISSUE_NUMBER). -->

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [ ] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [ ] I ran and verified that all tests pass according to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
